### PR TITLE
Incorrect assignment due to different types

### DIFF
--- a/clang_delta/RemoveUnusedStructField.cpp
+++ b/clang_delta/RemoveUnusedStructField.cpp
@@ -89,7 +89,7 @@ bool RemoveUnusedStructFieldRewriteVisitor::VisitRecordDecl(RecordDecl *RD)
   unsigned Idx = 0;
   for (RecordDecl::field_iterator I = RDDef->field_begin(),
        E = RDDef->field_end(); I != E; ++I) {
-    const FieldDecl *FD = (*I);
+    const FieldDecl *FD = &(*I);
     const Type *FDTy = FD->getType().getTypePtr();
     const RecordDecl *BaseRD = ConsumerInstance->getBaseRecordDef(FDTy);
     if (BaseRD)
@@ -154,7 +154,7 @@ void RemoveUnusedStructField::setBaseLine(const RecordDecl *RD,
 
   // IsLastField = (FD->getNextDeclInContext() == NULL);
   RecordDecl::field_iterator I = RD->field_begin();
-  IsFirstField = (FD == (*I));
+  IsFirstField = (FD == &(*I));
   RecordDecl::field_iterator E = RD->field_end();
 
   for (; I != E; ++I) {
@@ -211,7 +211,7 @@ const FieldDecl *RemoveUnusedStructField::getFieldDeclByIdx(
   for (RecordDecl::field_iterator RI = RD->field_begin(),
        RE = RD->field_end(); RI != RE; ++RI, ++I) {
     if (I == Idx)
-      return (*RI);
+      return &(*RI);
   }
   return NULL;
 }

--- a/clang_delta/UnionToStruct.cpp
+++ b/clang_delta/UnionToStruct.cpp
@@ -150,7 +150,7 @@ bool UnionToStruct::isValidRecordDecl(const RecordDecl *RD)
 
   for (RecordDecl::field_iterator I = RD->field_begin(),
        E = RD->field_end(); I != E; ++I) {
-    const FieldDecl *FD = (*I);
+    const FieldDecl *FD = &(*I);
     const Type *FDTy = FD->getType().getTypePtr();
     if (!FDTy->isScalarType())
       return false;
@@ -219,7 +219,7 @@ void UnionToStruct::getInitStrWithPointerType(const Expr *Exp, std::string &Str)
   QualType ETy = Exp->getType().getCanonicalType();
   for (; I != E; ++I) {
     Str += ",";
-    const FieldDecl *FD = (*I);
+    const FieldDecl *FD = &(*I);
     QualType FTy = FD->getType().getCanonicalType();
     if (ETy == FTy)
       Str += ExprStr;
@@ -245,7 +245,7 @@ void UnionToStruct::getInitStrWithNonPointerType(const Expr *Exp,
 
   for (; I != E; ++I) {
     Str += ",";
-    const FieldDecl *FD = (*I);
+    const FieldDecl *FD = &(*I);
     const Type *FTy = FD->getType().getTypePtr();
     if (FTy->isPointerType())
       Str += "0";


### PR DESCRIPTION
While trying to build (with gcc 4.6.3) clang-delta plugin I got these errors:

```
UnionToStruct.cpp: In member function ‘bool UnionToStruct::isValidRecordDecl(const clang::RecordDecl*)’:
UnionToStruct.cpp:153:30: error: cannot convert ‘clang::FieldDecl’ to ‘const clang::FieldDecl*’ in initialization
UnionToStruct.cpp: In member function ‘void UnionToStruct::getInitStrWithPointerType(const clang::Expr*, std::string&)’:
UnionToStruct.cpp:222:30: error: cannot convert ‘clang::FieldDecl’ to ‘const clang::FieldDecl*’ in initialization
UnionToStruct.cpp: In member function ‘void UnionToStruct::getInitStrWithNonPointerType(const clang::Expr*, std::string&)’:
UnionToStruct.cpp:248:30: error: cannot convert ‘clang::FieldDecl’ to ‘const clang::FieldDecl*’ in initialization
RemoveUnusedStructField.cpp: In member function ‘bool RemoveUnusedStructFieldRewriteVisitor::VisitRecordDecl(clang::RecordDecl*)’:
RemoveUnusedStructField.cpp:92:30: error: cannot convert ‘clang::FieldDecl’ to ‘const clang::FieldDecl*’ in initialization
RemoveUnusedStructField.cpp: In member function ‘void RemoveUnusedStructField::setBaseLine(const clang::RecordDecl*, const clang::FieldDecl*)’:
RemoveUnusedStructField.cpp:157:28: error: no match for ‘operator==’ in ‘FD == I.clang::DeclContext::specific_decl_iterator<SpecificDecl>::operator* [with SpecificDecl = clang::FieldDecl, clang::DeclContext::specific_decl_iterator<SpecificDecl>::reference = clang::FieldDecl&]()’
RemoveUnusedStructField.cpp:157:28: note: candidates are:
/localhome/pmatos/local/llvm-githead/include/clang/AST/CanonicalType.h:189:13: note: template<class T, class U> bool clang::operator==(clang::CanQual<T>, clang::CanQual<U>)
/localhome/pmatos/local/llvm-githead/include/clang/Basic/SourceLocation.h:172:13: note: bool clang::operator==(const clang::SourceLocation&, const clang::SourceLocation&)
/localhome/pmatos/local/llvm-githead/include/clang/Basic/SourceLocation.h:172:13: note:   no known conversion for argument 1 from ‘const clang::FieldDecl*’ to ‘const clang::SourceLocation&’
RemoveUnusedStructField.cpp: In member function ‘const clang::FieldDecl* RemoveUnusedStructField::getFieldDeclByIdx(const clang::RecordDecl*, unsigned int)’:
RemoveUnusedStructField.cpp:214:18: error: cannot convert ‘clang::FieldDecl’ to ‘const clang::FieldDecl*’ in return
```

This is all the same problem. The result of doing a *I where I is a fiel_iterator is a FieldDecl, not a FieldDecl*. 
