### PR TITLE
Fixed extraction of $toreduce_base.

### DIFF
--- a/creduce/creduce.in
+++ b/creduce/creduce.in
@@ -105,8 +105,6 @@ sub make_tmpdir () {
 }
 
 
-my @suffixes = (".c", ".C", ".cc", ".cpp", ".CPP", ".c++", ".cp", ".cxx");
-
 sub run_test ($) {
     (my $fn) = @_;
     my $res = runit "$test $fn >/dev/null 2>&1";
@@ -533,7 +531,7 @@ print "running $NPROCS interestingness tests in parallel\n";
 
 # Put scratch files ($toreduce_best, $toreduce_orig) in the current
 # working directory.
-($toreduce_base, $dir_base, $suffix) = fileparse($toreduce,@suffixes);
+($toreduce_base, $dir_base, $suffix) = fileparse($toreduce, '\.[^.]*');
 
 $ORIG_DIR = getcwd();
 


### PR DESCRIPTION
fileparse interpreted @suffixes as a list of patterns, and 'file.cc'
was split into 'file.' and 'cc' instead of 'file' and '.cc'
(because 'cc' matches '.c'), resulting in strange names of output
files (file..orig and file..best).

This fix also enables use of additional file extensions like '.h'
or '.ii'
