### PR TITLE
compile with llvm head

### DIFF
--- a/clang_delta/RemoveCtorInitializer.cpp
+++ b/clang_delta/RemoveCtorInitializer.cpp
@@ -124,7 +124,7 @@ bool RemoveCtorInitializer::isValidType(const Type *Ty)
     const CXXRecordDecl *CXXRD = dyn_cast<CXXRecordDecl>(RTy->getDecl());
     if (!CXXRD)
       return true;
-    return CXXRD->hasDeclaredDefaultConstructor();
+    return CXXRD->hasDefaultConstructor();
   }
   return true;
 }

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -732,7 +732,17 @@ bool RemoveNamespace::hasNameConflict(const NamedDecl *ND,
 
   DeclarationName Name = ND->getDeclName();
   DeclContextLookupConstResult Result = ParentCtx->lookup(Name);
-  return (Result.first != Result.second);
+
+  assert(!Result.empty());
+
+  // There is a conflict if the same name is declared more than once.
+  DeclContextLookupConstResult::iterator it;
+  for (it = Result.begin(); it != Result.end(); it++) {
+    if (*it != Result.front()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // We always prepend the Prefix string to EnumConstantDecl if ParentCtx

--- a/clang_delta/Transformation.cpp
+++ b/clang_delta/Transformation.cpp
@@ -454,7 +454,7 @@ const FunctionDecl *Transformation::lookupFunctionDeclInGlobal(
         DeclarationName &DName, const DeclContext *Ctx)
 {
   DeclContext::lookup_const_result Result = Ctx->lookup(DName);
-  for (DeclContext::lookup_const_iterator I = Result.first, E = Result.second;
+  for (DeclContext::lookup_const_iterator I = Result.begin(), E = Result.end();
        I != E; ++I) {
     if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(*I)) {
       return FD;
@@ -516,7 +516,7 @@ const FunctionDecl *Transformation::lookupFunctionDeclFromCtx(
         DeclarationName &DName, const DeclContext *Ctx)
 {
   DeclContext::lookup_const_result Result = Ctx->lookup(DName);
-  for (DeclContext::lookup_const_iterator I = Result.first, E = Result.second;
+  for (DeclContext::lookup_const_iterator I = Result.begin(), E = Result.end();
        I != E; ++I) {
     if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(*I)) {
       return FD;

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -87,7 +87,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
   ClangInstance = new CompilerInstance();
   assert(ClangInstance);
   
-  ClangInstance->createDiagnostics(0, NULL);
+  ClangInstance->createDiagnostics();
 
   CompilerInvocation &Invocation = ClangInstance->getInvocation();
   InputKind IK = FrontendOptions::getInputKindForExtension(
@@ -110,7 +110,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
   TargetOpts.Triple = LLVM_DEFAULT_TARGET_TRIPLE;
   TargetInfo *Target = 
     TargetInfo::CreateTargetInfo(ClangInstance->getDiagnostics(),
-                                 TargetOpts);
+                                 &TargetOpts);
   ClangInstance->setTarget(Target);
   ClangInstance->createFileManager();
   ClangInstance->createSourceManager(ClangInstance->getFileManager());

--- a/configure
+++ b/configure
@@ -15723,8 +15723,8 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-        #include <llvm/LLVMContext.h>
-#include <llvm/Module.h>
+        #include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
 int
 main ()
 {

--- a/m4/ax_llvm.m4
+++ b/m4/ax_llvm.m4
@@ -78,8 +78,8 @@ AC_DEFUN([AX_LLVM],
       AC_LANG_PUSH([C++])
       AC_LINK_IFELSE([
         AC_LANG_PROGRAM(
-          [[@%:@include <llvm/LLVMContext.h>
-@%:@include <llvm/Module.h>]],
+          [[@%:@include <llvm/IR/LLVMContext.h>
+@%:@include <llvm/IR/Module.h>]],
           [[llvm::LLVMContext context;
 llvm::Module *M = new llvm::Module("test", context);]])],
         ax_cv_llvm=yes,


### PR DESCRIPTION
I don't have a very good understanding of `llvm` internals, but to the best of my knowledge these commits are what is required to build with `llvm` head.

With these, the project builds with revision 183111:

```
areece-macbook-pro:creduce areece$ llvm-config --version
3.4svn
areece-macbook-pro:creduce areece$ clang --version
clang version 3.4 
Target: x86_64-apple-darwin12.3.0
Thread model: posix
```

I ran the tests as well, but I actually don't know how to interpret the results. I think they almost all passed? Here is some info, and I'll send more if you tell me what to look for. https://gist.github.com/awreece/5703282
