### PR TITLE
Fix a clang_delta assertion on __forceinline

### DIFF
--- a/clang_delta/ReplaceFunctionDefWithDecl.cpp
+++ b/clang_delta/ReplaceFunctionDefWithDecl.cpp
@@ -194,6 +194,8 @@ void ReplaceFunctionDefWithDecl::removeInlineKeywordFromOneFunctionDecl(
     return;
   if (removeInlineKeyword("__inline", Str, StartLoc))
     return;
+  if (removeInlineKeyword("__forceinline", Str, StartLoc))
+    return;
   TransAssert(0 && "Unreachable code!");
 }
 


### PR DESCRIPTION
Try removing __forceinline as a keyword along with inline and __inline.

Reduced test case is just: __forceinline void foo() { }
