### PR TITLE
Follow symlinks when determining whether the binary is executing from the installation directory

### DIFF
--- a/creduce/pass_clang.pm
+++ b/creduce/pass_clang.pm
@@ -30,7 +30,7 @@ my $ORIG_DIR;
 sub check_prereqs () {
     $ORIG_DIR = getcwd();
     my $path;
-    if ($FindBin::Bin eq bindir) {
+    if ($FindBin::RealBin eq bindir) {
 	# This script is in the installation directory.
 	# Use the installed `clang_delta'.
 	$path = libexecdir . "/clang_delta";

--- a/creduce/pass_clang_binsrch.pm
+++ b/creduce/pass_clang_binsrch.pm
@@ -40,7 +40,7 @@ sub count_instances ($$) {
 sub check_prereqs () {
     $ORIG_DIR = getcwd();
     my $path;
-    if ($FindBin::Bin eq bindir) {
+    if ($FindBin::RealBin eq bindir) {
 	# This script is in the installation directory.
 	# Use the installed `clang_delta'.
 	$path = libexecdir . "/clang_delta";

--- a/creduce/pass_clex.pm
+++ b/creduce/pass_clex.pm
@@ -30,7 +30,7 @@ my $ORIG_DIR;
 sub check_prereqs () {
     $ORIG_DIR = getcwd();
     my $path;
-    if ($FindBin::Bin eq bindir) {
+    if ($FindBin::RealBin eq bindir) {
 	# This script is in the installation directory.
 	# Use the installed `clex'.
 	$path = libexecdir . "/clex";


### PR DESCRIPTION
This was needed for compatibility with the Homebrew package manager, which creates a symlink in /usr/local/bin to creduce which is installed in a standalone container.
