### PR TITLE
Replace VarDecl::getFirstDecl with VarDecl::getCanonicalDecl

### DIFF
--- a/clang_delta/ReduceArraySize.cpp
+++ b/clang_delta/ReduceArraySize.cpp
@@ -167,7 +167,7 @@ void ReduceArraySize::rewriteArrayVarDecl(void)
   unsigned int Dim = getArrayDimension(ArrayTy);
   TransAssert((Dim > TheDimIdx) && "Bad Dimension Index!");
 
-  const VarDecl *FirstVD = TheVarDecl->getFirstDecl();
+  const VarDecl *FirstVD = TheVarDecl->getCanonicalDecl();
   for(VarDecl::redecl_iterator RI = FirstVD->redecls_begin(),
       RE = FirstVD->redecls_end(); RI != RE; ++RI) {
     BracketLocPair LocPair;

--- a/clang_delta/ReducePointerPairs.cpp
+++ b/clang_delta/ReducePointerPairs.cpp
@@ -280,7 +280,7 @@ void ReducePointerPairs::doAnalysis(void)
 
 void ReducePointerPairs::doRewriting(const VarDecl *VD)
 {
-  const VarDecl *FirstVD = VD->getFirstDecl();
+  const VarDecl *FirstVD = VD->getCanonicalDecl();
   for(VarDecl::redecl_iterator RI = FirstVD->redecls_begin(),
       RE = FirstVD->redecls_end(); RI != RE; ++RI) {
     RewriteHelper->removeAStarBefore(*RI); 

--- a/clang_delta/RemoveArray.cpp
+++ b/clang_delta/RemoveArray.cpp
@@ -196,7 +196,7 @@ void RemoveArray::getBracketLocPair(const VarDecl *VD,
 void RemoveArray::doRewriting(void)
 {
   // rewrite decls first
-  const VarDecl *FirstVD = TheArrayVarDecl->getFirstDecl();
+  const VarDecl *FirstVD = TheArrayVarDecl->getCanonicalDecl();
   for(VarDecl::redecl_iterator RI = FirstVD->redecls_begin(),
       RE = FirstVD->redecls_end(); RI != RE; ++RI) {
 

--- a/clang_delta/RemovePointer.cpp
+++ b/clang_delta/RemovePointer.cpp
@@ -147,7 +147,7 @@ void RemovePointer::doAnalysis(void)
 
 void RemovePointer::doRewriting(void)
 {
-  const VarDecl *FirstVD = TheVarDecl->getFirstDecl();
+  const VarDecl *FirstVD = TheVarDecl->getCanonicalDecl();
   for(VarDecl::redecl_iterator RI = FirstVD->redecls_begin(),
       RE = FirstVD->redecls_end(); RI != RE; ++RI) {
     RewriteHelper->removeAStarBefore(*RI); 

--- a/clang_delta/ReplaceFunctionDefWithDecl.cpp
+++ b/clang_delta/ReplaceFunctionDefWithDecl.cpp
@@ -208,7 +208,7 @@ void ReplaceFunctionDefWithDecl::removeInlineKeywordFromFunctionDecls(
   if (!FD->isInlineSpecified())
     return;
 
-  const FunctionDecl *FirstFD = FD->getFirstDecl();
+  const FunctionDecl *FirstFD = FD->getCanonicalDecl();
   for (FunctionDecl::redecl_iterator I = FirstFD->redecls_begin(),
        E = FirstFD->redecls_end(); I != E; ++I) {
     removeInlineKeywordFromOneFunctionDecl(*I);

--- a/clang_delta/ReturnVoid.cpp
+++ b/clang_delta/ReturnVoid.cpp
@@ -103,7 +103,7 @@ bool ReturnVoid::isNonVoidReturnFunction(FunctionDecl *FD)
   // then the type source info won't be available, let's try to
   // get one from the one which is in the source
   if (!FD->getTypeSourceInfo()) {
-    const FunctionDecl *FirstFD = FD->getFirstDecl();
+    const FunctionDecl *FirstFD = FD->getCanonicalDecl();
     FD = NULL;
     for (FunctionDecl::redecl_iterator I = FirstFD->redecls_begin(), 
          E = FirstFD->redecls_end(); I != E; ++I) {

--- a/clang_delta/SimpleInliner.cpp
+++ b/clang_delta/SimpleInliner.cpp
@@ -359,7 +359,7 @@ void SimpleInliner::doAnalysis(void)
     if (TransformationCounter == ValidInstanceNum) {
       // It's possible the direct callee is not a definition
       if (!CalleeDecl->isThisDeclarationADefinition()) {
-        CalleeDecl = CalleeDecl->getFirstDecl();
+        CalleeDecl = CalleeDecl->getCanonicalDecl();
         for(FunctionDecl::redecl_iterator RI = CalleeDecl->redecls_begin(),
             RE = CalleeDecl->redecls_end(); RI != RE; ++RI) {
           if ((*RI)->isThisDeclarationADefinition()) {

--- a/clang_delta/SimplifyStructUnionDecl.cpp
+++ b/clang_delta/SimplifyStructUnionDecl.cpp
@@ -182,7 +182,7 @@ bool SimplifyStructUnionDecl::isSafeToRemoveName(void)
     return false;
 
   const RecordDecl *RD = 
-    dyn_cast<RecordDecl>(TheRecordDecl->getFirstDecl());
+    dyn_cast<RecordDecl>(TheRecordDecl->getCanonicalDecl());
   RecordDecl::redecl_iterator I = RD->redecls_begin();
   RecordDecl::redecl_iterator E = RD->redecls_end();
   ++I;

--- a/clang_delta/UnifyFunctionDecl.cpp
+++ b/clang_delta/UnifyFunctionDecl.cpp
@@ -85,7 +85,7 @@ void UnifyFunctionDecl::doAnalysis(void)
     const FunctionDecl *FDDef = NULL; 
     const FunctionDecl *FDDecl = NULL;
     const FunctionDecl *CanonicalFD = (*I);
-    const FunctionDecl *FirstFD = CanonicalFD->getFirstDecl();
+    const FunctionDecl *FirstFD = CanonicalFD->getCanonicalDecl();
 
     FunctionDecl::redecl_iterator RI = FirstFD->redecls_begin();
     if (FirstFD->getSourceRange().isInvalid())

--- a/clang_delta/UnionToStruct.cpp
+++ b/clang_delta/UnionToStruct.cpp
@@ -185,7 +185,7 @@ void UnionToStruct::rewriteOneRecordDecl(const RecordDecl *RD)
 void UnionToStruct::rewriteRecordDecls(void)
 {
   const RecordDecl *RD = 
-    dyn_cast<RecordDecl>(TheRecordDecl->getFirstDecl());
+    dyn_cast<RecordDecl>(TheRecordDecl->getCanonicalDecl());
   TransAssert(RD && "NULL RecordDecl!");
   for(RecordDecl::redecl_iterator I = RD->redecls_begin(),
       E = RD->redecls_end(); I != E; ++I) {


### PR DESCRIPTION
I was having trouble building a C-Reduce with a slightly older version of Clang due to csmith-project/creduce@2417d62c73b17392a5874f32d9ae5653fb0c0fed. It seems that at some point Clang renamed `VarDecl::getFirstDeclaration()` to `VarDecl::getFirstDecl()`.

Now that I understand the root cause of my compilation problem, it's not unreasonable to reject this patch. But `VarDecl::getCanonicalDecl()` works in both versions.
