### PR TITLE
Improved transformations on structs

### DIFF
--- a/clang_delta/EmptyStructToInt.cpp
+++ b/clang_delta/EmptyStructToInt.cpp
@@ -437,11 +437,18 @@ bool EmptyStructToInt::isValidRecordDecl(const RecordDecl *RD)
 
   const DeclContext *Ctx = dyn_cast<DeclContext>(CXXDef);
   TransAssert(Ctx && "Invalid DeclContext!");
+  int count = 0;
   for (DeclContext::decl_iterator I = Ctx->decls_begin(),
        E = Ctx->decls_end(); I != E; ++I) {
+    if ((*I)->isReferenced())
+        return false;
     if (!(*I)->isImplicit())
-      return false;
+      ++count;
   }
+
+  if (count > 1)
+    return false;
+
   return true;
 }
 

--- a/clang_delta/EmptyStructToInt.cpp
+++ b/clang_delta/EmptyStructToInt.cpp
@@ -440,10 +440,11 @@ bool EmptyStructToInt::isValidRecordDecl(const RecordDecl *RD)
   int count = 0;
   for (DeclContext::decl_iterator I = Ctx->decls_begin(),
        E = Ctx->decls_end(); I != E; ++I) {
-    if ((*I)->isReferenced())
+    if (!(*I)->isImplicit()) {
+      if ((*I)->isReferenced())
         return false;
-    if (!(*I)->isImplicit())
       ++count;
+    }
   }
 
   if (count > 1)

--- a/clang_delta/EmptyStructToInt.h
+++ b/clang_delta/EmptyStructToInt.h
@@ -41,6 +41,9 @@ public:
 
 private:
 
+  typedef llvm::DenseMap<const clang::RecordDecl *, IndexVector *>
+    RecordDeclToFieldIdxVectorMap;
+
   typedef llvm::SmallPtrSet<const clang::RecordDecl *, 5> RecordDeclSet;
 
   typedef llvm::SmallPtrSet<const clang::CXXRecordDecl *, 20> CXXRecordDeclSet;
@@ -51,6 +54,13 @@ private:
 
   virtual void HandleTranslationUnit(clang::ASTContext &Ctx);
 
+  void handleOneRecordDecl(const clang::RecordDecl *RD,
+                           const clang::RecordDecl *BaseRD,
+                           const clang::FieldDecl *FD,
+                           unsigned int Idx);
+
+  void handleOneVarDecl(const clang::VarDecl *VD);
+
   bool isValidRecordDecl(const clang::RecordDecl *RD);
 
   bool pointToSelf(const clang::FieldDecl *FD);
@@ -58,6 +68,17 @@ private:
   void removeRecordDecls(void);
 
   void doAnalysis(void);
+
+  const clang::RecordDecl *getBaseRecordDef(const clang::Type *Ty);
+
+  void getInitExprs(const clang::Type *Ty, 
+                    const clang::Expr *E,
+                    const IndexVector *IdxVec,
+                    ExprVector &InitExprs);
+
+  const clang::FieldDecl *getFieldDeclByIdx(const clang::RecordDecl *RD, unsigned int Idx);
+
+  RecordDeclToFieldIdxVectorMap RecordDeclToField;
 
   RecordDeclSet VisitedRecordDecls;
 

--- a/clang_delta/RemoveUnusedStructField.cpp
+++ b/clang_delta/RemoveUnusedStructField.cpp
@@ -280,7 +280,6 @@ void RemoveUnusedStructField::getInitExprs(const Type *Ty,
 
     if (FD == TheFieldDecl) {
       InitExprs.push_back(Init);
-      //TODO: Is the (void)VecSz necessary?
       TransAssert((VecSz == 1) && "Bad IndexVector size!"); (void)VecSz;
     }
     else {
@@ -299,16 +298,12 @@ void RemoveUnusedStructField::removeOneInitExpr(const Expr *E)
 
   if (NumFields == 1) {
     // The last field can optionally have a trailing comma
-    // If this is the only field also the comma has to be removed together with the field
-    SourceLocation NewEndLoc = RewriteHelper->getEndLocationUntil(ExpRange, '}');
+    // If this is the only field also the comma has to be removed
+    SourceLocation NewEndLoc =
+      RewriteHelper->getEndLocationUntil(ExpRange, '}');
     NewEndLoc = NewEndLoc.getLocWithOffset(-1);
 
-    if (SrcManager->isBeforeInSLocAddrSpace(NewEndLoc, EndLoc)) {
-      TheRewriter.RemoveText(SourceRange(StartLoc, EndLoc));
-    }
-    else {
-      TheRewriter.RemoveText(SourceRange(StartLoc, NewEndLoc));
-    }
+    TheRewriter.RemoveText(SourceRange(StartLoc, NewEndLoc));
 
     return;
   }

--- a/clang_delta/RemoveUnusedStructField.cpp
+++ b/clang_delta/RemoveUnusedStructField.cpp
@@ -303,13 +303,11 @@ void RemoveUnusedStructField::removeOneInitExpr(const Expr *E)
     SourceLocation NewEndLoc = RewriteHelper->getEndLocationUntil(ExpRange, '}');
     NewEndLoc = NewEndLoc.getLocWithOffset(-1);
 
-    if(SrcManager->isBeforeInSLocAddrSpace(NewEndLoc, EndLoc))
-    {
-        TheRewriter.RemoveText(SourceRange(StartLoc, EndLoc));
+    if (SrcManager->isBeforeInSLocAddrSpace(NewEndLoc, EndLoc)) {
+      TheRewriter.RemoveText(SourceRange(StartLoc, EndLoc));
     }
-    else
-    {
-        TheRewriter.RemoveText(SourceRange(StartLoc, NewEndLoc));
+    else {
+      TheRewriter.RemoveText(SourceRange(StartLoc, NewEndLoc));
     }
 
     return;


### PR DESCRIPTION
This pull request fixes an issue with the transformation remove-unused-field. When the last item of an initialiser list with a trailing comma had been removed the list was left only with the comma inside. While a trailing comma after the last element is allowed the list with only the comma is syntactically incorrect.

Further the transformation empty-struct-to-int is extended. This pull request changes the behaviour such that any initialiser list for the struct under change is replace with a zero constant to initialise the new int variable. Without these changes undefined behaviour is introduced in the case of an array, struct or union as last unused field in the struct under change. After the struct under change is turned into an int any variable with the old struct type would potentially be initialised with an initialiser list. But the C99 standard forbids this (Sec 6.7.8 §2): "No initializer shall attempt to provide a value for an object not contained within the entity being initialized."

**Example for old behaviour:**
Before transformation:
```
struct S0 {
   int a[5];
}

struct S0 s = {{1,2,3,4,5}};
```
After transformation:
```
int s = {{1,2,3,4,5}};
```

With the changes of the pull request it will be `int s = 0`;