### PR TITLE
OpenCL support for clang_delta

### DIFF
--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -88,29 +88,30 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     // It results an empty AST for the caller. 
     Invocation.setLangDefaults(ClangInstance->getLangOpts(), IK_CXX);
   }
-  else if(IK == IK_OpenCL)
-  {
+  else if(IK == IK_OpenCL) {
       //Commandline parameters
-      std::vector<const char*> args;
-      args.push_back("-x");
-      args.push_back("cl");
-      args.push_back("-Dcl_clang_storage_class_specifiers");
+      std::vector<const char*> Args;
+      Args.push_back("-x");
+      Args.push_back("cl");
+      Args.push_back("-Dcl_clang_storage_class_specifiers");
 
-      const char *clcPath = getenv(CREDUCE_LIBCLC_INCLUDE_PATH);
+      const char *CLCPath = getenv("CREDUCE_LIBCLC_INCLUDE_PATH");
 
       ClangInstance->createFileManager();
 
-      if(clcPath != NULL && ClangInstance->hasFileManager() && ClangInstance->getFileManager().getDirectory(clcPath, false) != NULL)
-      {
-          args.push_back("-I");
-          args.push_back(clcPath);
+      if(CLCPath != NULL && ClangInstance->hasFileManager() &&
+         ClangInstance->getFileManager().getDirectory(CLCPath, false) != NULL) {
+          Args.push_back("-I");
+          Args.push_back(CLCPath);
       }
 
-      args.push_back("-include");
-      args.push_back("clc/clc.h");
-      args.push_back("-fno-builtin");
+      Args.push_back("-include");
+      Args.push_back("clc/clc.h");
+      Args.push_back("-fno-builtin");
 
-      CompilerInvocation::CreateFromArgs(Invocation, &args[0], &args[0] + args.size(), ClangInstance->getDiagnostics());
+      CompilerInvocation::CreateFromArgs(Invocation,
+                                         &Args[0], &Args[0] + Args.size(),
+                                         ClangInstance->getDiagnostics());
       Invocation.setLangDefaults(ClangInstance->getLangOpts(), IK_OpenCL);
   }
   else {

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -88,6 +88,31 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     // It results an empty AST for the caller. 
     Invocation.setLangDefaults(ClangInstance->getLangOpts(), IK_CXX);
   }
+  else if(IK == IK_OpenCL)
+  {
+      //Commandline parameters
+      std::vector<const char*> args;
+      args.push_back("-x");
+      args.push_back("cl");
+      args.push_back("-Dcl_clang_storage_class_specifiers");
+
+      const char *clcPath = getenv(CREDUCE_LIBCLC_INCLUDE_PATH);
+
+      ClangInstance->createFileManager();
+
+      if(clcPath != NULL && ClangInstance->hasFileManager() && ClangInstance->getFileManager().getDirectory(clcPath, false) != NULL)
+      {
+          args.push_back("-I");
+          args.push_back(clcPath);
+      }
+
+      args.push_back("-include");
+      args.push_back("clc/clc.h");
+      args.push_back("-fno-builtin");
+
+      CompilerInvocation::CreateFromArgs(Invocation, &args[0], &args[0] + args.size(), ClangInstance->getDiagnostics());
+      Invocation.setLangDefaults(ClangInstance->getLangOpts(), IK_OpenCL);
+  }
   else {
     ErrorMsg = "Unsupported file type!";
     return false;

--- a/clang_delta/TransformationManager.h
+++ b/clang_delta/TransformationManager.h
@@ -11,6 +11,8 @@
 #ifndef TRANSFORMATION_MANAGER_H
 #define TRANSFORMATION_MANAGER_H
 
+#define CREDUCE_LIBCLC_INCLUDE_PATH "CREDUCE_LIBCLC_INCLUDE_PATH"
+
 #include <string>
 #include <map>
 #include <cassert>

--- a/clang_delta/TransformationManager.h
+++ b/clang_delta/TransformationManager.h
@@ -11,8 +11,6 @@
 #ifndef TRANSFORMATION_MANAGER_H
 #define TRANSFORMATION_MANAGER_H
 
-#define CREDUCE_LIBCLC_INCLUDE_PATH "CREDUCE_LIBCLC_INCLUDE_PATH"
-
 #include <string>
 #include <map>
 #include <cassert>


### PR DESCRIPTION
This pull request adds automatic detection for OpenCL input. If the input file is assumed to contain OpenCL code the clang instance used by clang_delta is configured for OpenCL. Since clang does not know about the types defined in OpenCL and the functions the libclc headers have to be included. The path can be specified via an environment variable.

Further, the all *clang_delta* transformation are now considered as unsuccessful if any errors occurred during the parsing of the source code. I am not quite sure how useful this is but my intention was that if the creation of the AST goes wrong the transformations are likely to produce wrong code or do weird things.

Do you have any concerns about the changes?