### PR TITLE
Restrict transformations in clang_delta to rewrite only the main source file

### DIFF
--- a/clang_delta/AggregateToScalar.cpp
+++ b/clang_delta/AggregateToScalar.cpp
@@ -59,6 +59,13 @@ private:
 
 bool ATSCollectionVisitor::VisitMemberExpr(MemberExpr *ME)
 {
+  // Skip members which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(ME->getLocStart()))
+  {
+    return true;
+  }
+
   ValueDecl *OrigDecl = ME->getMemberDecl();
   FieldDecl *FD = dyn_cast<FieldDecl>(OrigDecl);
 
@@ -87,6 +94,13 @@ bool ATSCollectionVisitor::VisitArraySubscriptExpr(ArraySubscriptExpr *ASE)
   const Type *T = ASE->getType().getTypePtr();
   if (!T->isScalarType())
     return true;
+
+  // Skip subscripts which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(ASE->getLocStart()))
+  {
+    return true;
+  }
 
   ConsumerInstance->addOneExpr(ASE);
   return true;

--- a/clang_delta/BinOpSimplification.cpp
+++ b/clang_delta/BinOpSimplification.cpp
@@ -67,6 +67,13 @@ bool BSCollectionVisitor::VisitFunctionDecl(FunctionDecl *FD)
   if (!FD->isThisDeclarationADefinition())
     return true;
 
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
+
   ConsumerInstance->StmtVisitor->setCurrentFunctionDecl(FD);
   ConsumerInstance->StmtVisitor->TraverseDecl(FD);
   ConsumerInstance->StmtVisitor->setCurrentFunctionDecl(NULL);

--- a/clang_delta/CallExprToValue.cpp
+++ b/clang_delta/CallExprToValue.cpp
@@ -56,6 +56,13 @@ private:
 
 bool CallExprToValueVisitor::VisitCallExpr(CallExpr *CE)
 {
+  // Skip call expressions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(CE->getLocStart()))
+  {
+    return true;
+  }
+
   ConsumerInstance->ValidInstanceNum++;
   if (ConsumerInstance->TransformationCounter != 
       ConsumerInstance->ValidInstanceNum)

--- a/clang_delta/CombineLocalVarDecl.cpp
+++ b/clang_delta/CombineLocalVarDecl.cpp
@@ -94,6 +94,13 @@ bool CombLocalVarCollectionVisitor::VisitCompoundStmt(CompoundStmt *CS)
     DeclStmt *DS = dyn_cast<DeclStmt>(*I);
     if (!DS)
       continue;
+    // Skip declarations which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!ConsumerInstance->SrcManager->isInMainFile(DS->getLocStart()))
+    {
+      continue;
+    }
+
     const Type *T = getTypeFromDeclStmt(DS);
     if (!T)
       continue;

--- a/clang_delta/CopyPropagation.cpp
+++ b/clang_delta/CopyPropagation.cpp
@@ -414,6 +414,14 @@ void CopyPropagation::addOneDominatedExpr(const Expr *CopyE,
       hasSameStringRep(CopyE, DominatedE))
     return;
 
+  // Skip expressions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(CopyE->getLocStart()) ||
+     !SrcManager->isInMainFile(DominatedE->getLocStart()))
+  {
+    return;
+  }
+
   ExprSet *ESet = DominatedMap[CopyE];
   if (!ESet) {
     ESet = new ExprSet();

--- a/clang_delta/EmptyStructToInt.cpp
+++ b/clang_delta/EmptyStructToInt.cpp
@@ -80,6 +80,13 @@ bool EmptyStructToIntASTVisitor::VisitRecordDecl(RecordDecl *RD)
   if (!ConsumerInstance->isValidRecordDecl(RD))
     return true;
  
+  // Skip all structs that are not in the main file
+  // At the moment only rewriting of the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(RD->getLocation()))
+  {
+    return true;
+  }
+
   const RecordDecl *CanonicalRD = dyn_cast<RecordDecl>(RD->getCanonicalDecl());
   if (ConsumerInstance->VisitedRecordDecls.count(CanonicalRD))
     return true;
@@ -97,6 +104,13 @@ bool EmptyStructToIntASTVisitor::VisitCXXRecordDecl(CXXRecordDecl *CXXRD)
   if (!CanonicalRD->hasDefinition())
     return true;
 
+  // Skip all structs that are not in the main file
+  // At the moment only rewriting of the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(CXXRD->getLocation()))
+  {
+    return true;
+  }
+
   for (CXXRecordDecl::base_class_const_iterator I = 
        CanonicalRD->bases_begin(), E = CanonicalRD->bases_end(); I != E; ++I) {
     const CXXBaseSpecifier *BS = I;
@@ -110,6 +124,13 @@ bool EmptyStructToIntASTVisitor::VisitCXXRecordDecl(CXXRecordDecl *CXXRD)
 
 bool EmptyStructToIntRewriteVisitor::VisitRecordTypeLoc(RecordTypeLoc RTLoc)
 {
+  // Skip all definitions that are not in the main file
+  // At the moment only rewriting of the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(RTLoc.getLocStart()))
+  {
+    return true;
+  }
+
   const RecordDecl *RD = RTLoc.getDecl();
 
   if (RD->getCanonicalDecl() == ConsumerInstance->TheRecordDecl) {
@@ -135,6 +156,13 @@ bool EmptyStructToIntRewriteVisitor::VisitRecordTypeLoc(RecordTypeLoc RTLoc)
 bool EmptyStructToIntRewriteVisitor::VisitElaboratedTypeLoc(
        ElaboratedTypeLoc Loc)
 {
+  // Skip all definitions that are not in the main file
+  // At the moment only rewriting of the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(Loc.getLocStart()))
+  {
+    return true;
+  }
+
   const ElaboratedType *ETy = dyn_cast<ElaboratedType>(Loc.getTypePtr());
   const Type *NamedTy = ETy->getNamedType().getTypePtr();
   const RecordType *RDTy = NamedTy->getAs<RecordType>();
@@ -215,8 +243,16 @@ bool EmptyStructToIntRewriteVisitor::VisitRecordDecl(RecordDecl *RD)
 
 bool EmptyStructToIntRewriteVisitor::VisitVarDecl(VarDecl *VD)
 {
-  if (!VD->hasInit()) {
-    return true;
+  // Skip all definitions that are not in the main file
+  // At the moment only rewriting of the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(VD->getLocation()))
+  {
+      return true;
+  }
+
+  if(!VD->hasInit())
+  {
+      return true;
   }
 
   ConsumerInstance->handleOneVarDecl(VD);

--- a/clang_delta/LiftAssignmentExpr.cpp
+++ b/clang_delta/LiftAssignmentExpr.cpp
@@ -79,6 +79,13 @@ bool AssignExprCollectionVisitor::VisitFunctionDecl(FunctionDecl *FD)
   if (!FD->isThisDeclarationADefinition())
     return true;
 
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
+
   ConsumerInstance->StmtVisitor->setCurrentFunctionDecl(FD);
   ConsumerInstance->StmtVisitor->TraverseDecl(FD);
   ConsumerInstance->StmtVisitor->setCurrentFunctionDecl(NULL);

--- a/clang_delta/MoveFunctionBody.cpp
+++ b/clang_delta/MoveFunctionBody.cpp
@@ -43,6 +43,14 @@ bool MoveFunctionBody::HandleTopLevelDecl(DeclGroupRef D)
       continue;
     }
 
+    // Skip functions which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!SrcManager->isInMainFile(FD->getLocStart()))
+    {
+      PrevFunctionDecl = NULL;
+      continue;
+    }
+
     FunctionDecl *CanonicalFD = FD->getCanonicalDecl();
     if (FD->isThisDeclarationADefinition()) {
       FunctionDecl *FDDecl = AllValidFunctionDecls[CanonicalFD];

--- a/clang_delta/ParamToLocal.cpp
+++ b/clang_delta/ParamToLocal.cpp
@@ -169,6 +169,13 @@ bool ParamToLocal::isValidFuncDecl(FunctionDecl *FD)
 
   TransAssert(isa<FunctionDecl>(FD) && "Must be a FunctionDecl");
 
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return false;
+  }
+
   // Skip the case like foo(int, ...), because we cannot remove
   // the "int" there
   if (FD->isVariadic() && (FD->getNumParams() == 1)) {

--- a/clang_delta/ReduceArrayDim.cpp
+++ b/clang_delta/ReduceArrayDim.cpp
@@ -140,6 +140,13 @@ void ReduceArrayDim::HandleTranslationUnit(ASTContext &Ctx)
 
 void ReduceArrayDim::addOneVar(const VarDecl *VD)
 {
+  // Skip declarations which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(VD->getLocStart()))
+  {
+    return;
+  }
+
   const Type *Ty = VD->getType().getTypePtr();
   const ArrayType *ArrayTy = dyn_cast<ArrayType>(Ty);
   if (!ArrayTy)

--- a/clang_delta/ReduceArraySize.cpp
+++ b/clang_delta/ReduceArraySize.cpp
@@ -115,6 +115,13 @@ void ReduceArraySize::doAnalysis(void)
     if (!DimVec)
       continue;
 
+    // Skip declarations which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!SrcManager->isInMainFile(VD->getLocStart()))
+    {
+      continue;
+    }
+
     DimValueVector *OrigDimVec = OrigVarDeclToDim[VD];
     TransAssert(OrigDimVec && "Null OrigDimVec!");
 

--- a/clang_delta/ReducePointerLevel.cpp
+++ b/clang_delta/ReducePointerLevel.cpp
@@ -489,6 +489,13 @@ void ReducePointerLevel::doAnalysis(void)
          I != E; ++I) {
       if (!ValidDecls.count(*I))
         continue;
+      // Skip declarations which are not in the main file
+      // Rewriting outside of the main file is currently not supported
+      if(!SrcManager->isInMainFile((*I)->getLocStart()))
+      {
+        continue;
+      }
+
       ValidInstanceNum++;
       if (TransformationCounter == ValidInstanceNum)
         TheDecl = *I;

--- a/clang_delta/ReducePointerPairs.cpp
+++ b/clang_delta/ReducePointerPairs.cpp
@@ -270,6 +270,14 @@ void ReducePointerPairs::doAnalysis(void)
     if (!PairedVD)
       continue;
 
+    // Skip declarations which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!SrcManager->isInMainFile(I->first->getLocStart()) ||
+       !SrcManager->isInMainFile(I->second->getLocStart()))
+    {
+      continue;
+    }
+
     ValidInstanceNum++;
     if (TransformationCounter == ValidInstanceNum) {
       TheVarDecl = (*I).first;

--- a/clang_delta/RemoveAddrTaken.cpp
+++ b/clang_delta/RemoveAddrTaken.cpp
@@ -66,6 +66,13 @@ void RemoveAddrTakenCollectionVisitor::handleOneAddrTakenOp(
   if (ConsumerInstance->VisitedAddrTakenOps.count(UO))
     return;
 
+  // Skip operators which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(UO->getLocStart()))
+  {
+    return;
+  }
+
   ConsumerInstance->VisitedAddrTakenOps.insert(UO);
   ConsumerInstance->ValidInstanceNum++;
   if (ConsumerInstance->TransformationCounter == 

--- a/clang_delta/RemoveArray.cpp
+++ b/clang_delta/RemoveArray.cpp
@@ -94,6 +94,13 @@ private:
 
 bool RemoveArrayCollectionVisitor::VisitVarDecl(VarDecl *VD)
 {
+  // Skip declarations which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(VD->getLocStart()))
+  {
+    return true;
+  }
+
   ConsumerInstance->handleOneVarDecl(VD);
   return true;
 }
@@ -101,6 +108,13 @@ bool RemoveArrayCollectionVisitor::VisitVarDecl(VarDecl *VD)
 bool RemoveArrayCollectionVisitor::VisitArraySubscriptExpr(
        ArraySubscriptExpr *ASE)
 {
+  // Skip expressions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(ASE->getLocStart()))
+  {
+    return true;
+  }
+
   // we only have one-dimension array, so we are safe here.
   const Expr *BaseE = ASE->getBase()->IgnoreParenCasts();
   

--- a/clang_delta/RemoveEnumMemberValue.cpp
+++ b/clang_delta/RemoveEnumMemberValue.cpp
@@ -47,6 +47,13 @@ private:
 
 bool RemoveEnumMemberValueAnalysisVisitor::VisitEnumConstantDecl(EnumConstantDecl *ECD)
 {
+  // Skip enums which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(ECD->getLocStart()))
+  {
+    return true;
+  }
+
   if (!ECD->getInitExpr())
     return true;
 

--- a/clang_delta/RemoveNestedFunction.cpp
+++ b/clang_delta/RemoveNestedFunction.cpp
@@ -100,6 +100,13 @@ bool RNFStatementVisitor::VisitStmtExpr(StmtExpr *SE)
 
 bool RNFStatementVisitor::VisitCallExpr(CallExpr *CallE) 
 {
+  // Skip expressions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(CallE->getLocStart()))
+  {
+    return true;
+  }
+
   if (const CXXOperatorCallExpr *OpE = dyn_cast<CXXOperatorCallExpr>(CallE)) {
     if (ConsumerInstance->isInvalidOperator(OpE))
       return true;

--- a/clang_delta/RemovePointer.cpp
+++ b/clang_delta/RemovePointer.cpp
@@ -139,6 +139,13 @@ void RemovePointer::doAnalysis(void)
     if (AllInvalidPointerVarDecls.count(VD))
       continue;
 
+    // Skip declarations which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!SrcManager->isInMainFile(VD->getLocStart()))
+    {
+      continue;
+    }
+
     ValidInstanceNum++;
     if (TransformationCounter == ValidInstanceNum)
       TheVarDecl = VD;

--- a/clang_delta/RemoveUnusedEnumMember.cpp
+++ b/clang_delta/RemoveUnusedEnumMember.cpp
@@ -47,6 +47,13 @@ private:
 
 bool RemoveUnusedEnumMemberAnalysisVisitor::VisitEnumDecl(EnumDecl *ED)
 {
+  // Skip enums which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(ED->getLocStart()))
+  {
+    return true;
+  }
+
   if (ED != ED->getCanonicalDecl())
     return true;
 

--- a/clang_delta/RemoveUnusedFunction.cpp
+++ b/clang_delta/RemoveUnusedFunction.cpp
@@ -246,6 +246,13 @@ bool RUFAnalysisVisitor::VisitFunctionDecl(FunctionDecl *FD)
       !ConsumerInstance->hasAtLeastOneValidLocation(CanonicalFD))
     return true;
 
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
+
   ConsumerInstance->addOneFunctionDecl(CanonicalFD);
   return true;
 }

--- a/clang_delta/RemoveUnusedStructField.cpp
+++ b/clang_delta/RemoveUnusedStructField.cpp
@@ -71,6 +71,13 @@ bool RemoveUnusedStructFieldVisitor::VisitFieldDecl(FieldDecl *FD)
       ConsumerInstance->isSpecialRecordDecl(RD))
     return true;
 
+  // Skip field if it is not in the main file
+  // At the moment only rewriting of the main file is supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocation()))
+  {
+    return true;
+  }
+
   ConsumerInstance->ValidInstanceNum++;
   if (ConsumerInstance->ValidInstanceNum == 
       ConsumerInstance->TransformationCounter) {
@@ -191,6 +198,13 @@ void RemoveUnusedStructField::handleOneVarDecl(const VarDecl *VD)
   const RecordDecl *RD = getBaseRecordDef(Ty);
   if (!RD)
     return;
+
+  // Skip variable if it is not in the main file
+  // At the moment only rewriting of the main file is supported
+  if(!SrcManager->isInMainFile(VD->getLocation()))
+  {
+      return;
+  }
 
   IndexVector *IdxVec = RecordDeclToField[RD];
   if (!IdxVec)

--- a/clang_delta/RemoveUnusedVar.cpp
+++ b/clang_delta/RemoveUnusedVar.cpp
@@ -50,6 +50,13 @@ private:
 
 bool RemoveUnusedVarAnalysisVisitor::VisitVarDecl(VarDecl *VD)
 {
+  // Skip variables outside of the main file
+  // At the moment only rewriting of the main file is supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(VD->getLocation()))
+  {
+    return true;
+  }
+
   if (VD->isReferenced() || dyn_cast<ParmVarDecl>(VD) || 
       VD->isStaticDataMember())
     return true;

--- a/clang_delta/RenameFun.cpp
+++ b/clang_delta/RenameFun.cpp
@@ -75,6 +75,12 @@ bool RNFunCollectionVisitor::VisitFunctionDecl(FunctionDecl *FD)
     return true;
   }
 
+  // Skip functions outside of the main file
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
+
   const FunctionDecl *CanonicalFD = FD->getCanonicalDecl();
   ConsumerInstance->addFun(CanonicalFD);
   if (!ConsumerInstance->hasValidPostfix(FD->getNameAsString()))
@@ -88,6 +94,12 @@ bool RNFunCollectionVisitor::VisitCallExpr(CallExpr *CE)
   // It could happen, e.g., CE could refer to a DependentScopeDeclRefExpr
   if (!FD || dyn_cast<CXXMethodDecl>(FD))
     return true;
+
+  // Skip functions outside of the main file
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
 
   const FunctionDecl *CanonicalFD = FD->getCanonicalDecl();
 
@@ -107,6 +119,12 @@ bool RenameFunVisitor::VisitFunctionDecl(FunctionDecl *FD)
   if (dyn_cast<CXXMethodDecl>(FD))
     return true;
 
+  // Skip functions outside of the main file
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
+
   FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();
   llvm::DenseMap<const FunctionDecl *, std::string>::iterator I = 
     ConsumerInstance->FunToNameMap.find(CanonicalDecl);
@@ -124,6 +142,12 @@ bool RenameFunVisitor::VisitDeclRefExpr(DeclRefExpr *DRE)
   FunctionDecl *FD = dyn_cast<FunctionDecl>(OrigDecl);
   if (!FD || dyn_cast<CXXMethodDecl>(FD))
     return true;
+
+  // Skip functions outside of the main file
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
 
   FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();
   llvm::DenseMap<const FunctionDecl *, std::string>::iterator I = 

--- a/clang_delta/RenameParam.cpp
+++ b/clang_delta/RenameParam.cpp
@@ -70,6 +70,13 @@ bool ExistingVarCollectionVisitor::VisitVarDecl(VarDecl *VD)
 {
   ParmVarDecl *PD = dyn_cast<ParmVarDecl>(VD);
   if (PD) {
+    // Skip parameters which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!ConsumerInstance->SrcManager->isInMainFile(VD->getLocStart()))
+    {
+      return true;
+    }
+
     ConsumerInstance->validateParam(PD);
     return true;
   }

--- a/clang_delta/RenameVar.cpp
+++ b/clang_delta/RenameVar.cpp
@@ -73,6 +73,13 @@ bool RNVCollectionVisitor::VisitVarDecl(VarDecl *VD)
   if (PV)
     return true;
 
+  // Skip variables which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(VD->getLocStart()))
+  {
+    return true;
+  }
+
   VarDecl *CanonicalVD = VD->getCanonicalDecl();
   ConsumerInstance->addVar(CanonicalVD);
   return true;

--- a/clang_delta/ReplaceArrayIndexVar.cpp
+++ b/clang_delta/ReplaceArrayIndexVar.cpp
@@ -115,6 +115,13 @@ bool ReplaceArrayIndexVarCollectionVisitor::VisitVarDecl(VarDecl *VD)
 
 bool ReplaceArrayIndexVarCollectionVisitor::VisitForStmt(ForStmt *FS)
 {
+  // Skip loops outside of the main file
+  // They cannot be rewriten at the moment
+  if(!ConsumerInstance->SrcManager->isInMainFile(FS->getForLoc()))
+  {
+    return true;
+  }
+
   const Expr *Inc = FS->getInc();
   if (!Inc)
     return true;

--- a/clang_delta/ReplaceCallExpr.cpp
+++ b/clang_delta/ReplaceCallExpr.cpp
@@ -143,6 +143,13 @@ bool ReplaceCallExprVisitor::VisitReturnStmt(ReturnStmt *RS)
 
 bool ReplaceCallExprVisitor::VisitCallExpr(CallExpr *CE)
 {
+  // Skip call expression outside of the main file
+  // At the moment only rewriting within the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(CE->getLocStart()))
+  {
+      return true;
+  }
+
   FunctionDecl *FD = CE->getDirectCallee();
   if (!FD)
     return true;

--- a/clang_delta/ReplaceFunctionDefWithDecl.cpp
+++ b/clang_delta/ReplaceFunctionDefWithDecl.cpp
@@ -48,6 +48,13 @@ private:
 bool ReplaceFunctionDefWithDeclCollectionVisitor::VisitFunctionDecl(
        FunctionDecl *FD)
 {
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return true;
+  }
+
   if (FD->isThisDeclarationADefinition() && 
       !FD->isDeleted() &&
       !FD->isDefaulted() &&

--- a/clang_delta/ReplaceSimpleTypedef.cpp
+++ b/clang_delta/ReplaceSimpleTypedef.cpp
@@ -198,6 +198,13 @@ bool ReplaceSimpleTypedef::isValidType(const Type *Ty, const TypedefDecl *D)
 
 void ReplaceSimpleTypedef::handleOneTypedefDecl(const TypedefDecl *CanonicalD)
 {
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(CanonicalD->getLocStart()))
+  {
+    return;
+  }
+
   // omit some typedefs injected by Clang
   if (CanonicalD->getLocStart().isInvalid())
     return;

--- a/clang_delta/ReplaceUndefinedFunction.cpp
+++ b/clang_delta/ReplaceUndefinedFunction.cpp
@@ -84,6 +84,13 @@ bool ReplaceUndefFuncRewriteVisitor::VisitFunctionDecl(FunctionDecl *FD)
 
 bool ReplaceUndefFuncRewriteVisitor::VisitCallExpr(CallExpr *CE)
 {
+  // Only calls within the main file can considered
+  // Only rewriting within the main file is supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(CE->getLocStart()))
+  {
+    return true;
+  }
+
   FunctionDecl *FD = CE->getDirectCallee();
   // skip CXXMethodDecl for now
   if (!FD || dyn_cast<CXXMethodDecl>(FD))
@@ -147,19 +154,24 @@ void ReplaceUndefinedFunction::doAnalysis(void)
 
 void ReplaceUndefinedFunction::handleOneFunctionDecl(const FunctionDecl *FD)
 {
-  QualType FDQualTy = FD->getType();
-  for (FunctionSetMap::iterator I = ReplaceableFunctions.begin(),
-       E = ReplaceableFunctions.end(); I != E; ++I) {
-    const FunctionDecl *ReplaceableFD = (*I).first;
-    FunctionDeclSet *FDSet = (*I).second;
-    QualType QualTy = ReplaceableFD->getType();
+  // Only functions in the main file can be considred as replaced function
+  // Only rewriting within the main file is supported
+  if(SrcManager->isInMainFile(FD->getLocation()))
+  {
+    QualType FDQualTy = FD->getType();
+    for (FunctionSetMap::iterator I = ReplaceableFunctions.begin(),
+         E = ReplaceableFunctions.end(); I != E; ++I) {
+      const FunctionDecl *ReplaceableFD = (*I).first;
+      FunctionDeclSet *FDSet = (*I).second;
+      QualType QualTy = ReplaceableFD->getType();
 
-    if (!Context->hasSameType(FDQualTy, QualTy))
-      continue;
+      if (!Context->hasSameType(FDQualTy, QualTy))
+        continue;
 
-    TransAssert(FDSet && "NULL FDSet");
-    FDSet->insert(FD);
-    return;
+      TransAssert(FDSet && "NULL FDSet");
+      FDSet->insert(FD);
+      return;
+    }
   }
 
   FunctionDeclSet *FDSet = new FunctionDeclSet();

--- a/clang_delta/ReturnVoid.cpp
+++ b/clang_delta/ReturnVoid.cpp
@@ -67,6 +67,13 @@ private:
 
 bool RVCollectionVisitor::VisitFunctionDecl(FunctionDecl *FD)
 {
+  // Skip all function that are not in the main file
+  // At the moment only rewriting within the main file is possible
+  if(!ConsumerInstance->SrcManager->isInMainFile(FD->getLocation()))
+  {
+    return true;
+  }
+
   FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();
   if (ConsumerInstance->isNonVoidReturnFunction(CanonicalDecl)) {
     ConsumerInstance->ValidInstanceNum++;

--- a/clang_delta/SimpleInliner.cpp
+++ b/clang_delta/SimpleInliner.cpp
@@ -355,6 +355,13 @@ void SimpleInliner::doAnalysis(void)
     if (!hasValidArgExprs(*CI))
       continue;
 
+    // Skip calss which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!SrcManager->isInMainFile((*CI)->getLocStart()))
+    {
+      continue;
+    }
+
     ValidInstanceNum++;
     if (TransformationCounter == ValidInstanceNum) {
       // It's possible the direct callee is not a definition

--- a/clang_delta/SimplifyCallExpr.cpp
+++ b/clang_delta/SimplifyCallExpr.cpp
@@ -65,6 +65,13 @@ private:
 
 bool SimplifyCallExprVisitor::VisitCallExpr(CallExpr *CE)
 {
+  // Skip calls which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(CE->getLocStart()))
+  {
+    return true;
+  }
+
   ConsumerInstance->ValidInstanceNum++;
   if (ConsumerInstance->TransformationCounter != 
       ConsumerInstance->ValidInstanceNum)

--- a/clang_delta/SimplifyCommaExpr.cpp
+++ b/clang_delta/SimplifyCommaExpr.cpp
@@ -118,14 +118,19 @@ bool SimplifyCommaExprStmtVisitor::VisitDoStmt(DoStmt *DS)
 bool SimplifyCommaExprStmtVisitor::VisitBinaryOperator(
        BinaryOperator *BO)
 {
-  BinaryOperator::Opcode Op = BO->getOpcode();
-  if (Op == clang::BO_Comma) {
-    ConsumerInstance->ValidInstanceNum++;
-    if (ConsumerInstance->ValidInstanceNum == 
-        ConsumerInstance->TransformationCounter) {
-      ConsumerInstance->TheBinaryOperator = BO;
-      ConsumerInstance->TheStmt = CurrentStmt;
-      ConsumerInstance->NeedParen = NeedParen;
+  // Only handle commas which are in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(ConsumerInstance->SrcManager->isInMainFile(BO->getLocStart()))
+  {
+    BinaryOperator::Opcode Op = BO->getOpcode();
+    if (Op == clang::BO_Comma) {
+      ConsumerInstance->ValidInstanceNum++;
+      if (ConsumerInstance->ValidInstanceNum == 
+          ConsumerInstance->TransformationCounter) {
+        ConsumerInstance->TheBinaryOperator = BO;
+        ConsumerInstance->TheStmt = CurrentStmt;
+        ConsumerInstance->NeedParen = NeedParen;
+      }
     }
   }
 

--- a/clang_delta/SimplifyIf.cpp
+++ b/clang_delta/SimplifyIf.cpp
@@ -94,6 +94,13 @@ bool SimplifyIfCollectionVisitor::VisitFunctionDecl(FunctionDecl *FD)
 //     foo(bar())
 bool SimplifyIfStatementVisitor::VisitIfStmt(IfStmt *IS)
 {
+  // Skip statements which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(IS->getLocStart()))
+  {
+    return false;
+  }
+
   if (IS->getLocStart().isMacroID()) {
     return false;
   }

--- a/clang_delta/SimplifyStruct.cpp
+++ b/clang_delta/SimplifyStruct.cpp
@@ -79,6 +79,13 @@ private:
 
 bool SimplifyStructCollectionVisitor::VisitRecordDecl(RecordDecl *RD)
 {
+  // Skip records which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(RD->getLocStart()))
+  {
+    return true;
+  }
+
   if (!RD->isThisDeclarationADefinition() || !RD->isStruct())
     return true;
   if (ConsumerInstance->isSpecialRecordDecl(RD))
@@ -116,6 +123,13 @@ bool SimplifyStructCollectionVisitor::VisitRecordDecl(RecordDecl *RD)
 
 bool SimplifyStructRewriteVisitor::VisitVarDecl(VarDecl *VD)
 {
+  // Skip variables which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(VD->getLocStart()))
+  {
+    return true;
+  }
+
   if (!ConsumerInstance->ConstField && !ConsumerInstance->VolatileField)
     return true;
 
@@ -147,6 +161,13 @@ bool SimplifyStructRewriteVisitor::VisitVarDecl(VarDecl *VD)
 
 bool SimplifyStructRewriteVisitor::VisitRecordDecl(RecordDecl *RD)
 {
+  // Skip records which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(RD->getLocStart()))
+  {
+    return true;
+  }
+
   RecordDecl *CanonicalRD = dyn_cast<RecordDecl>(RD->getCanonicalDecl());
   if (CanonicalRD != ConsumerInstance->TheRecordDecl)
     return true;
@@ -178,6 +199,13 @@ bool SimplifyStructRewriteVisitor::VisitRecordDecl(RecordDecl *RD)
 
 bool SimplifyStructRewriteVisitor::VisitRecordTypeLoc(RecordTypeLoc RTLoc)
 {
+  // Skip type locations which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(RTLoc.getLocStart()))
+  {
+    return true;
+  }
+
   const Type *Ty = RTLoc.getTypePtr();
   if (Ty->isUnionType())
     return true;
@@ -200,6 +228,13 @@ bool SimplifyStructRewriteVisitor::VisitRecordTypeLoc(RecordTypeLoc RTLoc)
 
 bool SimplifyStructRewriteVisitor::VisitMemberExpr(MemberExpr *ME)
 {
+  // Skip expressions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!ConsumerInstance->SrcManager->isInMainFile(ME->getLocStart()))
+  {
+    return true;
+  }
+
   ValueDecl *OrigDecl = ME->getMemberDecl();
   FieldDecl *FD = dyn_cast<FieldDecl>(OrigDecl);
 

--- a/clang_delta/UnionToStruct.cpp
+++ b/clang_delta/UnionToStruct.cpp
@@ -167,6 +167,13 @@ void UnionToStruct::doAnalysis(void)
 {
   for (RecordDeclToDeclaratorDeclMap::iterator I = RecordToDeclarator.begin(),
        E = RecordToDeclarator.end(); I != E; ++I) {
+    // Skip records which are not in the main file
+    // Rewriting outside of the main file is currently not supported
+    if(!SrcManager->isInMainFile(I->first->getLocStart()))
+    {
+      continue;
+    }
+
     ValidInstanceNum++;
     if (ValidInstanceNum == TransformationCounter) {
       // TheRecordDecl = ((*I).first)->getDefinition();
@@ -178,6 +185,13 @@ void UnionToStruct::doAnalysis(void)
 
 void UnionToStruct::rewriteOneRecordDecl(const RecordDecl *RD)
 {
+  // Skip records which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(RD->getLocStart()))
+  {
+    return;
+  }
+
   TransAssert(RD && "NULL RecordDecl!");
   RewriteHelper->replaceUnionWithStruct(RD);
 }
@@ -195,6 +209,13 @@ void UnionToStruct::rewriteRecordDecls(void)
 
 void UnionToStruct::rewriteOneFieldDecl(const FieldDecl *FD)
 {
+  // Skip fields which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return;
+  }
+
   const DeclContext *Ctx = TheRecordDecl->getLexicalParent();
   // Skip the case where we have:
   // struct {
@@ -290,6 +311,13 @@ bool UnionToStruct::isTheFirstDecl(const VarDecl *VD)
 
 void UnionToStruct::rewriteOneVarDecl(const VarDecl *VD)
 {
+  // Skip variables which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(VD->getLocStart()))
+  {
+    return;
+  }
+
   if (dyn_cast<ParmVarDecl>(VD)) {
     RewriteHelper->replaceUnionWithStruct(VD);
     return; 
@@ -363,6 +391,13 @@ void UnionToStruct::rewriteOneVarDecl(const VarDecl *VD)
 
 void UnionToStruct::rewriteOneFunctionDecl(const FunctionDecl *FD)
 {
+  // Skip functions which are not in the main file
+  // Rewriting outside of the main file is currently not supported
+  if(!SrcManager->isInMainFile(FD->getLocStart()))
+  {
+    return;
+  }
+
   RewriteHelper->replaceUnionWithStruct(FD);
 }
 


### PR DESCRIPTION
This pull request is a follow-up on #64. The handling of OpenCL files in #64 requires the additional include of the libclc header files. Clang_delta also searched this header files for transformation instances and crashed if it tried to rewrite something in the header files.

These changes restrict the transformations to operate only on the main source file. This should not change the behaviour of clang_delta if it is used with preprocessed files as before since then everything is in the main source file. As an exception I have to mention that the preprocessed file must not contain these info lines about the original source location that the preprocessor adds, like `# 52 "/home/moritz/clsmith/kernels.hyyppy/CLProg_112.cl"`. Clangs seems to handle contents after these lines still as external contents even if it now in the one source file. Maybe there is another check that could be used to exclude header files which is not affected by these info lines.

For some transformations the changes are more restrictive than they would have to be. For instance, the transformation `replace-one-level-typedef-type` is now limited to the main source file. But it could search all header files for typedefs and replace occurrences in the main source file. But it would not be allowed to remove the typedef from the header file once no further usages are found. This causes the problem that the typedef in the header file would be found over and over again and the transformation could not proceed. Thus I decided to choose the more restrictive approach for the moment.

Also, like for C the CXX specific transformations are disabled for OpenCL.

Are you interested in such a change? Or would you prefer not to restrict the rewriting?