### PR TITLE
Disable some clang_delta transformations for OpenCL

### DIFF
--- a/clang_delta/ClassTemplateToClass.cpp
+++ b/clang_delta/ClassTemplateToClass.cpp
@@ -203,7 +203,8 @@ void ClassTemplateToClass::Initialize(ASTContext &context)
 
 void ClassTemplateToClass::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/InstantiateTemplateParam.cpp
+++ b/clang_delta/InstantiateTemplateParam.cpp
@@ -168,7 +168,8 @@ void InstantiateTemplateParam::Initialize(ASTContext &context)
 
 void InstantiateTemplateParam::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/InstantiateTemplateTypeParamToInt.cpp
+++ b/clang_delta/InstantiateTemplateTypeParamToInt.cpp
@@ -204,7 +204,8 @@ void InstantiateTemplateTypeParamToInt::Initialize(ASTContext &context)
 
 void InstantiateTemplateTypeParamToInt::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/LocalToGlobal.cpp
+++ b/clang_delta/LocalToGlobal.cpp
@@ -139,7 +139,13 @@ void LocalToGlobal::Initialize(ASTContext &context)
 
 void LocalToGlobal::HandleTranslationUnit(ASTContext &Ctx)
 {
-  FunctionVisitor->TraverseDecl(Ctx.getTranslationUnitDecl());
+  if (TransformationManager::isOpenCLLangOpt()) {
+    ValidInstanceNum = 0;
+  }
+  else {
+    FunctionVisitor->TraverseDecl(Ctx.getTranslationUnitDecl());
+  }
+
   if (QueryInstanceOnly)
     return;
 

--- a/clang_delta/ParamToGlobal.cpp
+++ b/clang_delta/ParamToGlobal.cpp
@@ -103,7 +103,13 @@ void ParamToGlobal::Initialize(ASTContext &context)
 
 void ParamToGlobal::HandleTranslationUnit(ASTContext &Ctx)
 {
-  CollectionVisitor->TraverseDecl(Ctx.getTranslationUnitDecl());
+  if (TransformationManager::isOpenCLLangOpt()) {
+    ValidInstanceNum = 0;
+  }
+  else {
+    CollectionVisitor->TraverseDecl(Ctx.getTranslationUnitDecl());
+  }
+
   if (QueryInstanceOnly)
     return;
 

--- a/clang_delta/ReduceClassTemplateParameter.cpp
+++ b/clang_delta/ReduceClassTemplateParameter.cpp
@@ -250,7 +250,8 @@ void ReduceClassTemplateParameter::Initialize(ASTContext &context)
 
 void ReduceClassTemplateParameter::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RemoveBaseClass.cpp
+++ b/clang_delta/RemoveBaseClass.cpp
@@ -82,7 +82,8 @@ void RemoveBaseClass::Initialize(ASTContext &context)
 
 void RemoveBaseClass::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RemoveCtorInitializer.cpp
+++ b/clang_delta/RemoveCtorInitializer.cpp
@@ -99,7 +99,8 @@ void RemoveCtorInitializer::Initialize(ASTContext &context)
 
 void RemoveCtorInitializer::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RemoveTrivialBaseTemplate.cpp
+++ b/clang_delta/RemoveTrivialBaseTemplate.cpp
@@ -60,7 +60,8 @@ void RemoveTrivialBaseTemplate::Initialize(ASTContext &context)
 
 void RemoveTrivialBaseTemplate::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RemoveUnresolvedBase.cpp
+++ b/clang_delta/RemoveUnresolvedBase.cpp
@@ -84,7 +84,8 @@ void RemoveUnresolvedBase::Initialize(ASTContext &context)
 
 void RemoveUnresolvedBase::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RemoveUnusedFunction.cpp
+++ b/clang_delta/RemoveUnusedFunction.cpp
@@ -240,6 +240,7 @@ bool RUFAnalysisVisitor::VisitFunctionDecl(FunctionDecl *FD)
 
   if (FD->isReferenced() || 
       FD->isMain() || 
+      FD->hasAttr<OpenCLKernelAttr>() ||
       ConsumerInstance->hasReferencedSpecialization(CanonicalFD) ||
       ConsumerInstance->isInlinedSystemFunction(CanonicalFD) ||
       ConsumerInstance->isInReferencedSet(CanonicalFD) ||

--- a/clang_delta/RemoveUnusedOuterClass.cpp
+++ b/clang_delta/RemoveUnusedOuterClass.cpp
@@ -81,7 +81,8 @@ void RemoveUnusedOuterClass::Initialize(ASTContext &context)
 
 void RemoveUnusedOuterClass::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RenameClass.cpp
+++ b/clang_delta/RenameClass.cpp
@@ -78,7 +78,8 @@ void RenameClass::Initialize(ASTContext &context)
 
 void RenameClass::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/RenameFun.cpp
+++ b/clang_delta/RenameFun.cpp
@@ -242,7 +242,7 @@ void RenameFun::addFun(const FunctionDecl *FD)
 {
   std::string Name = FD->getNameAsString();
   // Skip special functions
-  if (isSpecialFun(Name))
+  if (isSpecialFun(Name) || FD->hasAttr<OpenCLKernelAttr>())
     FunToNameMap[FD] = Name;
 
   if (FunToNameMap.find(FD) != FunToNameMap.end())

--- a/clang_delta/ReplaceClassWithBaseTemplateSpec.cpp
+++ b/clang_delta/ReplaceClassWithBaseTemplateSpec.cpp
@@ -96,7 +96,8 @@ void ReplaceClassWithBaseTemplateSpec::Initialize(ASTContext &context)
 
 void ReplaceClassWithBaseTemplateSpec::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/ReplaceDependentName.cpp
+++ b/clang_delta/ReplaceDependentName.cpp
@@ -71,7 +71,8 @@ void ReplaceDependentName::Initialize(ASTContext &context)
 
 void ReplaceDependentName::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/ReplaceDependentTypedef.cpp
+++ b/clang_delta/ReplaceDependentTypedef.cpp
@@ -77,7 +77,8 @@ void ReplaceDependentTypedef::Initialize(ASTContext &context)
 
 void ReplaceDependentTypedef::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/ReplaceDerivedClass.cpp
+++ b/clang_delta/ReplaceDerivedClass.cpp
@@ -73,7 +73,8 @@ void ReplaceDerivedClass::Initialize(ASTContext &context)
 
 void ReplaceDerivedClass::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/SimplifyDependentTypedef.cpp
+++ b/clang_delta/SimplifyDependentTypedef.cpp
@@ -114,7 +114,8 @@ void SimplifyDependentTypedef::Initialize(ASTContext &context)
 
 void SimplifyDependentTypedef::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
 

--- a/clang_delta/SimplifyNestedClass.cpp
+++ b/clang_delta/SimplifyNestedClass.cpp
@@ -105,7 +105,8 @@ void SimplifyNestedClass::Initialize(ASTContext &context)
 
 void SimplifyNestedClass::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/SimplifyRecursiveTemplateInstantiation.cpp
+++ b/clang_delta/SimplifyRecursiveTemplateInstantiation.cpp
@@ -99,7 +99,8 @@ void SimplifyRecursiveTemplateInstantiation::Initialize(ASTContext &context)
 void
 SimplifyRecursiveTemplateInstantiation::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/TemplateArgToInt.cpp
+++ b/clang_delta/TemplateArgToInt.cpp
@@ -203,7 +203,8 @@ void TemplateArgToInt::Initialize(ASTContext &context)
 
 void TemplateArgToInt::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/TemplateNonTypeArgToInt.cpp
+++ b/clang_delta/TemplateNonTypeArgToInt.cpp
@@ -87,7 +87,8 @@ void TemplateNonTypeArgToInt::Initialize(ASTContext &context)
 
 void TemplateNonTypeArgToInt::HandleTranslationUnit(ASTContext &Ctx)
 {
-  if (TransformationManager::isCLangOpt()) {
+  if (TransformationManager::isCLangOpt() ||
+      TransformationManager::isOpenCLLangOpt()) {
     ValidInstanceNum = 0;
   }
   else {

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -64,6 +64,15 @@ bool TransformationManager::isCLangOpt()
           .C99);
 }
 
+bool TransformationManager::isOpenCLLangOpt()
+{
+  TransAssert(TransformationManager::Instance && "Invalid Instance!");
+  TransAssert(TransformationManager::Instance->ClangInstance &&
+              "Invalid ClangInstance!");
+  return (TransformationManager::Instance->ClangInstance->getLangOpts()
+          .OpenCL);
+}
+
 bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
 {
   if (ClangInstance) {

--- a/clang_delta/TransformationManager.h
+++ b/clang_delta/TransformationManager.h
@@ -37,6 +37,8 @@ public:
 
   static bool isCLangOpt();
 
+  static bool isOpenCLLangOpt();
+
   static int ErrorInvalidCounter;
 
   bool doTransformation(std::string &ErrorMsg, int &ErrorCode);


### PR DESCRIPTION
This pull request disables some clang_delta transformations for OpenCL input files. For example, the param-to-global transformation does not work for OpenCL as there are no C-like globals.