### PR TITLE
Teach clang_delta how to break "trivial" inheritance chains.

### DIFF
--- a/clang_delta/RemoveTrivialBaseTemplate.cpp
+++ b/clang_delta/RemoveTrivialBaseTemplate.cpp
@@ -104,9 +104,8 @@ void RemoveTrivialBaseTemplate::handleOneCXXRecordDecl(
     const CXXBaseSpecifier *BS = I;
     const Type *Ty = BS->getType().getTypePtr();
     const CXXRecordDecl *Base = getBaseDeclFromType(Ty);
-    if (!Base || Base->hasDefinition()) {
+    if (!Base)
       continue;
-    }
     const ClassTemplateDecl *TmplD = Base->getDescribedClassTemplate();
     if (!TmplD)
       continue;

--- a/clang_delta/test/RemoveTrivialBaseTemplate.cpp
+++ b/clang_delta/test/RemoveTrivialBaseTemplate.cpp
@@ -1,0 +1,16 @@
+//RUN: %clang_delta --transformation=remove-trivial-base-template --counter=1 %s | FileCheck %s
+namespace std {
+  template <typename T, typename U> class iterator{};
+}
+template<typename T, typename U>
+struct TriaRawIterator : public std::iterator<T, U> {
+  int pinHere;
+};
+
+//CHECK: namespace std {
+//CHECK-NEXT:  template <typename T, typename U> class iterator{};
+//CHECK-NEXT: }
+//CHECK-NEXT: template<typename T, typename U>
+//CHECK-NEXT: struct TriaRawIterator  {
+//CHECK-NEXT:   int pinHere;
+//CHECK-NEXT: };


### PR DESCRIPTION
Perhaps, RemoveTrivialBaseTemplate could be merged in RemoveBaseClass, as it starts to handle less trivial cases.