### PR TITLE
Make RenameFun ignore functions declared in included files

### DIFF
--- a/clang_delta/RenameFun.cpp
+++ b/clang_delta/RenameFun.cpp
@@ -133,7 +133,8 @@ bool RenameFunVisitor::VisitDeclRefExpr(DeclRefExpr *DRE)
 
   ValueDecl *OrigDecl = DRE->getDecl();
   FunctionDecl *FD = dyn_cast<FunctionDecl>(OrigDecl);
-  if (!FD || dyn_cast<CXXMethodDecl>(FD))
+  if (!FD || dyn_cast<CXXMethodDecl>(FD) ||
+      ConsumerInstance->isInIncludedFile(FD))
     return true;
 
   FunctionDecl *CanonicalDecl = FD->getCanonicalDecl();


### PR DESCRIPTION
There was a mismatch in the RenameFun translation where functions
declared in included files were ignored when collecting information on
which functions to replace but not when performing the actual
replacement.