### PR TITLE
Fix condition logic in RenameClass::isValidName

### DIFF
--- a/clang_delta/RenameClass.cpp
+++ b/clang_delta/RenameClass.cpp
@@ -160,7 +160,7 @@ bool RenameClass::isValidName(const std::string &Name)
     return false;
 
   char C = Name[0];
-  return (((C >= 'A') || (C <= 'Z')) && !isReservedName(C));
+  return (((C >= 'A') && (C <= 'Z')) && !isReservedName(C));
 }
 
 void RenameClass::addOneRecordDecl(const CXXRecordDecl *CanonicalRD,


### PR DESCRIPTION
Detected by GCC's "logical-op" check:

    RenameClass.cpp: In member function ‘bool RenameClass::isValidName(const string&)’:
    RenameClass.cpp:163:23: warning: logical ‘or’ of collectively exhaustive tests is always true [-Wlogical-op]
        return (((C >= 'A') || (C <= 'Z')) && !isReservedName(C));
                 ~~~~~~~~~~~^~~~~~~~~~~~~