### PR TITLE
Fix #99: Add missing copyright message

### DIFF
--- a/clang_delta/ReplaceArrayAccessWithIndex.cpp
+++ b/clang_delta/ReplaceArrayAccessWithIndex.cpp
@@ -1,3 +1,12 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2016 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
 
 #if HAVE_CONFIG_H
 #  include <config.h>

--- a/clang_delta/ReplaceArrayAccessWithIndex.h
+++ b/clang_delta/ReplaceArrayAccessWithIndex.h
@@ -1,3 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2016 The University of Utah
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
 #ifndef REPLACE_ARRAY_ACCESS_WITH_INDEX
 #define REPLACE_ARRAY_ACCESS_WITH_INDEX
 


### PR DESCRIPTION
I added a copyright notice to the files. They are licenced under the same terms as the rest of creduce.
