### PR TITLE
drop_front doesn't mutate the string but rather returns the new string:

### DIFF
--- a/clang_delta/RenameCXXMethod.cpp
+++ b/clang_delta/RenameCXXMethod.cpp
@@ -429,9 +429,8 @@ bool RenameCXXMethod::isValidName(const StringRef &Name)
   StringRef NamePrefix = Name.substr(0, PrefixLen);
   if (!NamePrefix.equals(MethodNamePrefix))
     return false;
-  Name.drop_front(PrefixLen);
   llvm::APInt Num;
-  return Name.getAsInteger(10, Num);
+  return Name.drop_front(PrefixLen).getAsInteger(10, Num);
 }
 
 void RenameCXXMethod::addOneMethodName(const CXXMethodDecl *MD,


### PR DESCRIPTION
http://llvm.org/docs/doxygen/html/classllvm_1_1StringRef.html#ad977ad21e398b4cda9801dc8e86cf169

Can you verify that this fix looks right, Yang? Thanks!