### PR TITLE
Fix broken topformflat invocation

### DIFF
--- a/creduce/pass_lines.pm
+++ b/creduce/pass_lines.pm
@@ -82,7 +82,7 @@ sub transform ($$$) {
 	print "***TRANSFORM START***\n" if $DEBUG;
 	delete $sh{"start"};
 	my $outfile = File::Temp::tmpnam();
-	my $cmd = qq{"$topformflat $arg" < $cfile > $outfile};
+	my $cmd = qq{"$topformflat" $arg < $cfile > $outfile};
 	print $cmd if $DEBUG;
 	runit ($cmd);
 


### PR DESCRIPTION
When I created the fix for Windows I misplaced a quotation mark. Unfortunately it works fine on Windows but causes the following error on Unix systems.

```
sh: /Users/Moritz/Programming/clreduce/install/libexec/topformflat 0: No such file or directory
```