### PR TITLE
Fix non-deterministic clang_delta transformations

### DIFF
--- a/clang_delta/EmptyStructToInt.h
+++ b/clang_delta/EmptyStructToInt.h
@@ -11,6 +11,7 @@
 #ifndef EMPTY_STRUCT_TO_INT_H
 #define EMPTY_STRUCT_TO_INT_H
 
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "Transformation.h"
 
@@ -44,7 +45,7 @@ private:
   typedef llvm::DenseMap<const clang::RecordDecl *, IndexVector *>
     RecordDeclToFieldIdxVectorMap;
 
-  typedef llvm::SmallPtrSet<const clang::RecordDecl *, 5> RecordDeclSet;
+  typedef llvm::SetVector<const clang::RecordDecl *> RecordDeclSet;
 
   typedef llvm::SmallPtrSet<const clang::CXXRecordDecl *, 20> CXXRecordDeclSet;
 

--- a/clang_delta/ReduceArraySize.h
+++ b/clang_delta/ReduceArraySize.h
@@ -13,7 +13,7 @@
 
 #include <string>
 #include <utility>
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "Transformation.h"
 
@@ -46,7 +46,7 @@ private:
   
   typedef llvm::SmallVector<int, 10> DimValueVector;
 
-  typedef llvm::DenseMap<const clang::VarDecl *, DimValueVector *> 
+  typedef llvm::MapVector<const clang::VarDecl *, DimValueVector *> 
             VarDeclToDimMap;
 
   typedef std::pair<clang::SourceLocation, clang::SourceLocation>

--- a/clang_delta/RemoveArray.h
+++ b/clang_delta/RemoveArray.h
@@ -13,8 +13,8 @@
 
 #include <utility>
 #include "Transformation.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/DenseMap.h"
 
 namespace clang {
   class DeclGroupRef;
@@ -46,7 +46,7 @@ private:
   typedef llvm::SmallVector<clang::ArraySubscriptExpr *, 10> 
     ArraySubscriptExprVector;
 
-  typedef llvm::DenseMap<const clang::VarDecl *, ArraySubscriptExprVector *> 
+  typedef llvm::MapVector<const clang::VarDecl *, ArraySubscriptExprVector *> 
     VarDeclToArraySubscriptExprMap;
 
   typedef std::pair<clang::SourceLocation, clang::SourceLocation>

--- a/clang_delta/RemovePointer.cpp
+++ b/clang_delta/RemovePointer.cpp
@@ -133,7 +133,7 @@ void RemovePointer::HandleTranslationUnit(ASTContext &Ctx)
 
 void RemovePointer::doAnalysis(void)
 {
-  for (VarDeclSet::iterator I = AllPointerVarDecls.begin(),
+  for (VarDeclSetVector::iterator I = AllPointerVarDecls.begin(),
        E = AllPointerVarDecls.end(); I != E; ++I) {
     const VarDecl *VD = (*I);
     if (AllInvalidPointerVarDecls.count(VD))

--- a/clang_delta/RemovePointer.h
+++ b/clang_delta/RemovePointer.h
@@ -13,6 +13,7 @@
 
 #include <utility>
 #include "Transformation.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace clang {
@@ -40,6 +41,7 @@ public:
 private:
 
   typedef llvm::SmallPtrSet<const clang::VarDecl *, 10> VarDeclSet;
+  typedef llvm::SetVector<const clang::VarDecl *> VarDeclSetVector;
 
   virtual void Initialize(clang::ASTContext &context);
 
@@ -53,7 +55,7 @@ private:
 
   void invalidateOneVarDecl(const clang::DeclRefExpr *DRE);
 
-  VarDeclSet AllPointerVarDecls;
+  VarDeclSetVector AllPointerVarDecls;
 
   VarDeclSet AllInvalidPointerVarDecls;
 

--- a/clang_delta/RemoveUnusedOuterClass.cpp
+++ b/clang_delta/RemoveUnusedOuterClass.cpp
@@ -109,7 +109,7 @@ void RemoveUnusedOuterClass::HandleTranslationUnit(ASTContext &Ctx)
 
 void RemoveUnusedOuterClass::analyzeCXXRDSet()
 {
-  for (CXXRecordDeclSet::iterator I = CXXRDDefSet.begin(), 
+  for (CXXRecordDeclSetVector::iterator I = CXXRDDefSet.begin(), 
        E = CXXRDDefSet.end(); I != E; ++I) {
     const CXXRecordDecl *Def = (*I);
     if (UsedCXXRDSet.count(Def->getCanonicalDecl()))

--- a/clang_delta/RemoveUnusedOuterClass.h
+++ b/clang_delta/RemoveUnusedOuterClass.h
@@ -11,6 +11,7 @@
 #ifndef REMOVE_UNUSED_OUTER_CLASS_H
 #define REMOVE_UNUSED_OUTER_CLASS_H
 
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "Transformation.h"
 
@@ -36,6 +37,7 @@ public:
 
 private:
   typedef llvm::SmallPtrSet<const clang::CXXRecordDecl *, 10> CXXRecordDeclSet;
+  typedef llvm::SetVector<const clang::CXXRecordDecl *> CXXRecordDeclSetVector;
 
   virtual void Initialize(clang::ASTContext &context);
 
@@ -47,7 +49,7 @@ private:
 
   CXXRecordDeclSet UsedCXXRDSet;
 
-  CXXRecordDeclSet CXXRDDefSet;
+  CXXRecordDeclSetVector CXXRDDefSet;
 
   RemoveUnusedOuterClassVisitor *CollectionVisitor;
 

--- a/clang_delta/ReplaceOneLevelTypedefType.h
+++ b/clang_delta/ReplaceOneLevelTypedefType.h
@@ -12,7 +12,7 @@
 #define REPLACE_ONE_LEVEL_TYPEDEF_TYPE_H
 
 #include "Transformation.h"
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "clang/AST/TypeLoc.h"
 
@@ -40,7 +40,7 @@ private:
   typedef llvm::SmallVector<clang::TypedefTypeLoc, 10>
     TypedefTypeLocVector;
 
-  typedef llvm::DenseMap<const clang::TypedefDecl *, 
+  typedef llvm::MapVector<const clang::TypedefDecl *, 
                          TypedefTypeLocVector *>
     TypedefDeclToRefMap;
 

--- a/clang_delta/ReplaceUndefinedFunction.h
+++ b/clang_delta/ReplaceUndefinedFunction.h
@@ -12,8 +12,8 @@
 #define REPLACE_UNDEFINED_FUNCTION_H
 
 #include <string>
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SetVector.h"
 #include "Transformation.h"
 
 namespace clang {
@@ -43,10 +43,10 @@ public:
 
 private:
   
-  typedef llvm::SmallPtrSet<const clang::FunctionDecl *, 10>
+  typedef llvm::SetVector<const clang::FunctionDecl *>
             FunctionDeclSet;
 
-  typedef llvm::DenseMap<const clang::FunctionDecl *, FunctionDeclSet *>
+  typedef llvm::MapVector<const clang::FunctionDecl *, FunctionDeclSet *>
             FunctionSetMap;
 
   virtual void Initialize(clang::ASTContext &context);

--- a/clang_delta/UnionToStruct.h
+++ b/clang_delta/UnionToStruct.h
@@ -12,6 +12,7 @@
 #define UNION_TO_STRUCT_H
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "Transformation.h"
 
@@ -52,7 +53,7 @@ private:
   typedef llvm::DenseMap<const clang::VarDecl *, clang::DeclGroupRef> 
             VarToDeclGroupMap;
 
-  typedef llvm::DenseMap<const clang::RecordDecl *, DeclaratorDeclSet *> 
+  typedef llvm::MapVector<const clang::RecordDecl *, DeclaratorDeclSet *> 
             RecordDeclToDeclaratorDeclMap;
 
   virtual void Initialize(clang::ASTContext &context);


### PR DESCRIPTION
For some transformations the order of the possible transformations within the test case is non-deterministic. This is because the instances are stored in maps or sets which are ordered by pointer values.
This PR replaces those maps and sets with ones that keep the insertion order.

For an example you can use the `compiler-crashes/00/small.cpp` test case.
```
clang_delta --transformation=empty-struct-to-int --counter=1 small.cpp
```

If you run it multiple times (without changing small.cpp in between) you will get different results for the transformed small.cpp because every time another empty struct is selected for `--counter=1`.