### PR TITLE
[clang_delta] Link against LLVMSupport to fix missing APInt methods

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -35,6 +35,7 @@ llvm_map_components_to_libnames(LLVM_LIBS
   mcparser
   option
   profiledata
+  support
 )
 
 set(CLANG_LIBS


### PR DESCRIPTION
Link clang_delta against LLVMSupport in order to fix the following link
failure:

```
/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/../../../../x86_64-pc-linux-gnu/bin/ld: CMakeFiles/clang_delta.dir/ReplaceArrayIndexVar.cpp.o: undefined reference to symbol '_ZN4llvm5APInt12initSlowCaseERKS0_'
/usr/lib64/libLLVMSupport.so.40: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
