### PR TITLE
Fix build on Windows

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -213,6 +213,10 @@ add_executable(clang_delta
 
 target_link_libraries(clang_delta ${CLANG_LIBS} ${LLVM_LIBS})
 
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    target_link_libraries(clang_delta Version)
+endif()
+
 install(TARGETS clang_delta
   RUNTIME DESTINATION "libexec"
 )


### PR DESCRIPTION
On Windows the clang dependencies require to link against `Version`.