### PR TITLE
clang_delta: Namespace-qualify clang::StringLiteral

### DIFF
--- a/clang_delta/ExpressionDetector.cpp
+++ b/clang_delta/ExpressionDetector.cpp
@@ -452,8 +452,8 @@ bool ExpressionDetector::isIdenticalExpr(const Expr *E1, const Expr *E2)
   }
 
   case Stmt::StringLiteralClass: {
-    const StringLiteral *Lit1 = cast<StringLiteral>(E1);
-    const StringLiteral *Lit2 = cast<StringLiteral>(E2);
+    const clang::StringLiteral *Lit1 = cast<clang::StringLiteral>(E1);
+    const clang::StringLiteral *Lit2 = cast<clang::StringLiteral>(E2);
     return Lit1->getBytes() == Lit2->getBytes();
   }
 


### PR DESCRIPTION
Use clang::StringLiteral rather than relying on the using statement
since llvm::StringLiteral was introduced lately and made plain
'StringLiteral' ambiguous.