### PR TITLE
Require package Clang for clang_delta

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -160,6 +160,14 @@ find LLVM/Clang:
   # Use the LLVM/Clang tree rooted at /opt/llvm
   cmake [source-dir] -DCMAKE_PREFIX_PATH=/opt/llvm
 
+Alternatively, if you choose to build LLVM and Clang yourself, you can
+set `LLVM_DIR` and/or `Clang_DIR` to paths where Cmake can find the
+`LLVMConfig.cmake` and/or `ClangConfig.cmake`. This is usually
+`./lib/cmake/{llvm,clang}` relative to the build or install directory.
+Note that it is required to actually build LLVM and Clang before
+building C-Reduce. Just configuring LLVM and Clang via CMake does not
+generate all files required.
+
 Note that assertions are enabled by default (which is probably what
 you want).  To disable assertions:
 

--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -14,6 +14,7 @@ project(clang_delta)
 ###############################################################################
 
 # find_package(LLVM) is done by the topmost "CMakeLists.txt" file.
+find_package(Clang REQUIRED CONFIG NO_CMAKE_BUILDS_PATH)
 
 # Generate file "git_version.cpp".
 #
@@ -28,6 +29,8 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
 include_directories(${CMAKE_BINARY_DIR})
 include_directories(${PROJECT_SOURCE_DIR}) # needed for gen'ed .cpp files
 include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${CLANG_INCLUDE_DIRS})
+
 link_directories(${LLVM_LIBRARY_DIRS})
 
 llvm_map_components_to_libnames(LLVM_LIBS


### PR DESCRIPTION
If LLVM and Clang have not been installed into the same location it is
necessary to specify the include directory for the clang headers
separate from the LLVM include directory.