### PR TITLE
Remove try catch

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -158,6 +158,8 @@ add_executable(clang_delta
   RemovePointer.h
   RemoveTrivialBaseTemplate.cpp
   RemoveTrivialBaseTemplate.h
+  RemoveTryCatch.cpp
+  RemoveTryCatch.h
   RemoveUnresolvedBase.cpp
   RemoveUnresolvedBase.h
   RemoveUnusedEnumMember.cpp

--- a/clang_delta/RemoveTryCatch.cpp
+++ b/clang_delta/RemoveTryCatch.cpp
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012, 2013, 2015 The University of Utah
+// Copyright (c) 2012 Konstantin Tokarev <annulen@yandex.ru>
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include "RemoveTryCatch.h"
+
+#include <cctype>
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/Basic/SourceManager.h"
+
+#include "TransformationManager.h"
+
+using namespace clang;
+
+static const char *DescriptionMsg =
+"Remove catch blocks and if not present the try block as well. \n";
+
+static RegisterTransformation<RemoveTryCatch>
+         Trans("remove-try-catch", DescriptionMsg);
+
+class RemoveTryCatchAnalysisVisitor : public
+  RecursiveASTVisitor<RemoveTryCatchAnalysisVisitor> {
+public:
+
+  explicit RemoveTryCatchAnalysisVisitor(RemoveTryCatch *Instance)
+    : ConsumerInstance(Instance)
+  { }
+
+  bool VisitCXXTryStmt(CXXTryStmt *CTS);
+
+private:
+
+  RemoveTryCatch *ConsumerInstance;
+};
+
+bool RemoveTryCatchAnalysisVisitor::VisitCXXTryStmt(
+       CXXTryStmt *CTS)
+{
+  if (ConsumerInstance->isInIncludedFile(CTS)) {
+    return true;
+  }
+
+  // Count try block
+  ++ConsumerInstance->ValidInstanceNum;
+
+  if (ConsumerInstance->TransformationCounter <
+      ConsumerInstance->ValidInstanceNum) {
+    return true;
+  }
+
+  // Count all catch blocks
+  ConsumerInstance->ValidInstanceNum += CTS->getNumHandlers();
+
+  if (ConsumerInstance->TransformationCounter >
+      ConsumerInstance->ValidInstanceNum) {
+    return true;
+  }
+
+  // If no catch blocks are left remove the try
+  // else delete the specified catch block
+  if (ConsumerInstance->TransformationCounter ==
+      ConsumerInstance->ValidInstanceNum) {
+    ConsumerInstance->TheTryCatchStmt = CTS;
+  } else {
+    int CatchIdx = ConsumerInstance->ValidInstanceNum -
+      ConsumerInstance->TransformationCounter - 1;
+    ConsumerInstance->TheTryCatchStmt = CTS->getHandler(CatchIdx);
+  }
+
+  return true;
+}
+
+void RemoveTryCatch::Initialize(ASTContext &context)
+{
+  Transformation::Initialize(context);
+  AnalysisVisitor = new RemoveTryCatchAnalysisVisitor(this);
+}
+
+void RemoveTryCatch::HandleTranslationUnit(ASTContext &Ctx)
+{
+  AnalysisVisitor->TraverseDecl(Ctx.getTranslationUnitDecl());
+
+  if (QueryInstanceOnly)
+    return;
+
+  if (TransformationCounter > ValidInstanceNum) {
+    TransError = TransMaxInstanceError;
+    return;
+  }
+
+  Ctx.getDiagnostics().setSuppressAllDiagnostics(false);
+
+  TransAssert(TheTryCatchStmt && "NULL TheTryCatchStmt!");
+
+  removeStmt();
+
+  if (Ctx.getDiagnostics().hasErrorOccurred() ||
+      Ctx.getDiagnostics().hasFatalErrorOccurred())
+    TransError = TransInternalError;
+}
+
+void RemoveTryCatch::removeStmt()
+{
+  SourceManager &SrcManager = TheRewriter.getSourceMgr();
+  SourceRange Range = TheTryCatchStmt->getSourceRange();
+  TheRewriter.RemoveText(Range);
+}
+
+RemoveTryCatch::~RemoveTryCatch()
+{
+  delete AnalysisVisitor;
+}

--- a/clang_delta/RemoveTryCatch.h
+++ b/clang_delta/RemoveTryCatch.h
@@ -30,6 +30,7 @@ public:
   RemoveTryCatch(const char *TransName, const char *Desc)
     : Transformation(TransName, Desc),
       AnalysisVisitor(0),
+      RewriteTryStmt(0),
       TheTryCatchStmt(0)
   { }
 
@@ -45,6 +46,7 @@ private:
 
   RemoveTryCatchAnalysisVisitor *AnalysisVisitor;
 
+  clang::Stmt *RewriteTryStmt;
   clang::Stmt *TheTryCatchStmt;
 
   // Unimplemented

--- a/clang_delta/RemoveTryCatch.h
+++ b/clang_delta/RemoveTryCatch.h
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) 2012 The University of Utah
+// Copyright (c) 2012 Konstantin Tokarev <annulen@yandex.ru>
+// All rights reserved.
+//
+// This file is distributed under the University of Illinois Open Source
+// License.  See the file COPYING for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef REMOVE_TRY_CATCH_H
+#define REMOVE_TRY_CATCH_H
+
+#include <string>
+#include "llvm/ADT/DenseMap.h"
+#include "Transformation.h"
+
+namespace clang {
+  class Stmt;
+}
+
+class RemoveTryCatchAnalysisVisitor;
+
+class RemoveTryCatch : public Transformation {
+friend class RemoveTryCatchAnalysisVisitor;
+
+public:
+
+  RemoveTryCatch(const char *TransName, const char *Desc)
+    : Transformation(TransName, Desc),
+      AnalysisVisitor(0),
+      TheTryCatchStmt(0)
+  { }
+
+  ~RemoveTryCatch();
+
+private:
+
+  virtual void Initialize(clang::ASTContext &context);
+
+  virtual void HandleTranslationUnit(clang::ASTContext &Ctx);
+
+  void removeStmt();
+
+  RemoveTryCatchAnalysisVisitor *AnalysisVisitor;
+
+  clang::Stmt *TheTryCatchStmt;
+
+  // Unimplemented
+  RemoveTryCatch();
+
+  RemoveTryCatch(const RemoveTryCatch &);
+
+  void operator=(const RemoveTryCatch &);
+};
+#endif

--- a/creduce/creduce.in
+++ b/creduce/creduce.in
@@ -851,6 +851,7 @@ my @all_methods = (
     { "name" => "pass_clang",    "arg" => "replace-dependent-name", "pri" => 257, "C" => 1,  },
     { "name" => "pass_clang",    "arg" => "simplify-recursive-template-instantiation",       "pri" => 258, "C" => 1, },
     { "name" => "pass_clang",    "arg" => "vector-to-array",        "pri" => 259, "C" => 1,   },
+    { "name" => "pass_clang",    "arg" => "remove-try-catch",        "pri" => 260, "C" => 1,   },
     { "name" => "pass_clang",    "arg" => "combine-global-var",                    "last_pass_pri" => 990, "C" => 1, },
     { "name" => "pass_clang",    "arg" => "combine-local-var",                     "last_pass_pri" => 991, "C" => 1, },
     { "name" => "pass_clang",    "arg" => "simplify-struct-union-decl",            "last_pass_pri" => 992, "C" => 1, },


### PR DESCRIPTION
The new pass tries to remove:
(1) the whole try-catch statement
(2) every single catch block
(3) the `try` keyword together with the last `catch`-block (a `try` without any `catch` is invalid) 

For now I just added the pass at the end of the primary run. That might need to be changed to a better position.

The attached file can be used to get an idea how the transformations work (rename to .cpp).
[try_catch.txt](https://github.com/csmith-project/creduce/files/1814788/try_catch.txt)


