### PR TITLE
stop using dead sys::cpu perl module

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -73,25 +73,19 @@ zlib:
 --------------------------------------------------------------------
 Optional prereqs:
 
-Term::ReadKey, and Sys::CPU are optional; C-Reduce will use whichever
-of them are installed.
-
-In particular, we recommend installing Sys::CPU; without this module
-C-Reduce will not use multiple cores unless explicitly requested to do
-so with the -n command line option.
+Term::ReadKey is optional; C-Reduce will use it if it is installed.
 
 On Ubuntu:
 
-  sudo apt-get install libterm-readkey-perl libsys-cpu-perl
+  sudo apt-get install libterm-readkey-perl
 
 On OS X (with Homebrew + Perlbrew installed):
 
   cpan -i 'Term::ReadKey'
-  cpan -i 'Sys::CPU'
 
 On FreeBSD 10.3:
 
-  sudo pkg install p5-Term-ReadKey p5-Sys-CPU
+  sudo pkg install p5-Term-ReadKey
 
 Otherwise, install the packages either manually or using the package
 manager.

--- a/creduce/creduce_utils.pm
+++ b/creduce/creduce_utils.pm
@@ -124,9 +124,6 @@ sub ncpus () {
     if ($OS eq "MSWin32") {
 	# TODO
     }
-    # Load and use the Sys::CPU module if available, don't complain otherwise
-    # we try this last since it will count hyperthreads not cores
-    return Sys::CPU::cpu_count() if (eval { require Sys::CPU; });
     return 1;
 }
 


### PR DESCRIPTION
Turns out sys::cpu was only used on platforms that aren't Linux or OS X. I can't imagine we have many users on those platforms. Just default to one core in that case since Sys::CPU seems to have died in CPAN. People can still override using a command line flag.