### PR TITLE
Fix option name

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ compiler leaves files in /tmp when it is killed, C-Reduce has no way
 to discover and remove the files. You will need to do this manually
 from time to time if temporary file space is limited. The leakage is
 typically pretty slow. If you need to avoid this problem altogether,
-you can run C-Reduce on a single core (using "-n 1") in which case
+you can run C-Reduce on a single core (using "--n 1") in which case
 C-Reduce will never kill a running compiler instance. Alternatively, a
 command line option such as -pipe (supported by gcc) may suppress the
 creation of temporary files altogether. Another possibility is to set

--- a/creduce/creduce_utils.pm
+++ b/creduce/creduce_utils.pm
@@ -129,7 +129,7 @@ sub ncpus () {
 
 # here we're pretty conservative about the number of parallel
 # processes to use; if the user has some big iron she can specify a
-# higher number using -n
+# higher number using --n
 sub nprocs () {
     my $cpus = ncpus();
     die unless ($cpus >= 1);


### PR DESCRIPTION
`-n` was renamed as `--n` in e5c6db7cd95459b1271f9027c31ee4706da063b6, but documentation and comments weren't updated.