### PR TITLE
Check number of CPUs only if --n wasn't specified

### DIFF
--- a/creduce/creduce.in
+++ b/creduce/creduce.in
@@ -45,7 +45,7 @@ if ($^O eq "MSWin32") {
 use creduce_config qw(PACKAGE_STRING);
 use creduce_utils;
 
-my $NPROCS = nprocs();
+my $NPROCS;
 
 ######################################################################
 
@@ -208,6 +208,7 @@ Getopt::Tabular::SetOptionPatterns qw|(--)([\w-]+) (-)(\w+)|;
 Getopt::Tabular::SetHelpOption("--help");
 GetOptions(\@options, \@ARGV) or exit(1);
 usage() unless (@ARGV >= 2);
+defined $NPROCS or $NPROCS = nprocs();
 
 my @custom_methods;
 


### PR DESCRIPTION
I have a very old Linux kernel (2.6.32) here, which makes lscpu fail:
```
lscpu: failed to determine number of CPUs: /sys/devices/system/cpu/possible: No such file or directory
```
I don't mind specifying `--n` manually, but I don't want to see the error message when I do.