### PR TITLE
Use a different name for the sub loop

### DIFF
--- a/clang_delta/ReduceArraySize.cpp
+++ b/clang_delta/ReduceArraySize.cpp
@@ -120,9 +120,9 @@ void ReduceArraySize::doAnalysis(void)
     unsigned int DimSz = DimVec->size();
     TransAssert((DimSz == OrigDimVec->size()) &&
                 "Two DimValueVectors should have the same size!");
-    for (unsigned int I = 0; I < DimSz; ++I) {
-      int DimV = (*DimVec)[I];
-      int OrigDimV = (*OrigDimVec)[I];
+    for (unsigned int II = 0; II < DimSz; ++II) {
+      int DimV = (*DimVec)[II];
+      int OrigDimV = (*OrigDimVec)[II];
       if ((DimV == -1) || (OrigDimV == 0) || ((DimV+1) == OrigDimV))
         continue;
 
@@ -132,7 +132,7 @@ void ReduceArraySize::doAnalysis(void)
 
       TheVarDecl = VD;
       TheDimValue = DimV;
-      TheDimIdx = I;
+      TheDimIdx = II;
     }
   }
 }


### PR DESCRIPTION
Hi all,
There is reused variable name issue found by Qihoo360 CodeSafe Team.

Since variable 'I' is already used as the iterator in for in line 108, in line 123, it is better to use another variable as the counter for the for loop.

Cheers
Qihoo360 CodeSafe Team