### PR TITLE
Add a pass to remove constant ifs

### DIFF
--- a/creduce/creduce.in
+++ b/creduce/creduce.in
@@ -755,12 +755,12 @@ sub line_delta_pass ($) {
 my @all_methods = (
 
     { "name" => "pass_include_includes", "arg" => "0",               "pri" => 100, "C" => 1, },
-    { "name" => "pass_includes", "arg" => "0",                                      "first_pass_pri" =>  0, "C" => 1, },
     { "name" => "pass_unifdef",  "arg" => "0",                       "pri" => 450,  "first_pass_pri" =>  0, "C" => 1, },
     { "name" => "pass_comments", "arg" => "0",                       "pri" => 451,  "first_pass_pri" =>  0, "C" => 1, },
-    { "name" => "pass_blank",    "arg" => "0",                                      "first_pass_pri" =>  1, },
-    { "name" => "pass_clang_binsrch",    "arg" => "replace-function-def-with-decl", "first_pass_pri" =>  2, "C" => 1, },
-    { "name" => "pass_clang_binsrch",    "arg" => "remove-unused-function",         "first_pass_pri" =>  3, "C" => 1, },
+    { "name" => "pass_includes", "arg" => "0",                                      "first_pass_pri" =>  1, "C" => 1, },
+    { "name" => "pass_blank",    "arg" => "0",                                      "first_pass_pri" =>  2, },
+    { "name" => "pass_clang_binsrch",    "arg" => "replace-function-def-with-decl", "first_pass_pri" =>  3, "C" => 1, },
+    { "name" => "pass_clang_binsrch",    "arg" => "remove-unused-function",         "first_pass_pri" =>  4, "C" => 1, },
 
     { "name" => "pass_lines",    "arg" => "0",                      "pri" => 410,  "first_pass_pri" =>  20,   "last_pass_pri" => 999, },
     { "name" => "pass_lines",    "arg" => "1",                      "pri" => 411,  "first_pass_pri" =>  21, },

--- a/creduce/pass_unifdef.pm
+++ b/creduce/pass_unifdef.pm
@@ -49,7 +49,7 @@ sub check_prereqs () {
 }
 
 sub new ($$) {
-    my $index = 0;
+    my $index = -1;
     return \$index;
 }
 
@@ -72,6 +72,19 @@ sub transform ($$$) {
     close INF;
     my @deflist = sort keys %defs;
     my $tmpfile = File::Temp::tmpnam();
+
+    # remove constant ifs
+    if ($index == -1) {
+	my $cmd = "$unifdef -k -o $tmpfile $cfile >/dev/null 2>&1";
+	runit ($cmd);
+	$index++;
+	if (compare($cfile, $tmpfile) == 0) {
+	    goto AGAIN;
+        }
+	File::Copy::move($tmpfile, $cfile);
+	return ($OK, \$index);
+    }
+
   AGAIN:
     print "index = $index\n" if $DEBUG;
     my $DU = (($index % 2) == 0) ? "-D" : "-U";


### PR DESCRIPTION
This adds a part to pass_unifdef that removes constant #if statements. The reordering is for the possibility that includes get nested under ifs.