### PR TITLE
llvm7: cmake fix linking

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -57,16 +57,14 @@ include_directories(${CLANG_INCLUDE_DIRS}) # only works for LLVM post-4.0
 
 link_directories(${LLVM_LIBRARY_DIRS})
 
-llvm_map_components_to_libnames(LLVM_LIBS
-  coverage
-  irreader
-  mcparser
-  objcarcopts
-  option
-  passes
-  profiledata
-  support
-)
+find_program(LLVM_CONFIG_EXECUTABLE NAMES llvm-config DOC "llvm-config executable")
+if (NOT LLVM_CONFIG_EXECUTABLE STREQUAL "LLVM_CONFIG_EXECUTABLE-NOTFOUND")
+  execute_process(
+    COMMAND ${LLVM_CONFIG_EXECUTABLE} --libs coverage irreader mcparser objcarcopts option passes profiledata support
+    OUTPUT_VARIABLE LLVM_LIBS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif()
 
 set(CLANG_LIBS
   clangStaticAnalyzerFrontend
@@ -242,11 +240,7 @@ add_executable(clang_delta
   git_version.h
 )
 
-# ENE, LLVM 6.0: LLVM_LIBS end up in the link command line anyway.  I'm not
-# quite sure why!  But if you list LLVM_LIBS here, the `clang_delta' binary
-# can end up with dynamic link errors when it runs (multiply defined symbols).
-#
-target_link_libraries(clang_delta ${CLANG_LIBS})
+target_link_libraries(clang_delta ${CLANG_LIBS} ${LLVM_LIBS})
 
 # Custom target for running clang_delta tests
 #


### PR DESCRIPTION
This patch should not make things any worse because we were not using the LLVM_LIBS variable anyways originally as explained in the removed comment.

The removed comment says that LLVM_LIBS are linked but it doesn't happen for me with LLVM 7.

Other than that, I replaced the call to `llvm_map_components_to_libnames` with `llvm-config` because in some platforms, especially when your LLVM is provided by your distro, only a single DSO is provided (libLLVM-7.so), instead of separate .so for each library. So providing separate libnames to linker will not work. Delegating our job to `llvm-config` is better as it will automatically detect whether system provides single DSO or seperated DSO.

