### PR TITLE
Link clang_delta only with -lclang-cpp (#193).

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -86,24 +86,7 @@ llvm_map_components_to_libnames(LLVM_LIBS
 )
 
 set(CLANG_LIBS
-  clangStaticAnalyzerFrontend
-  clangStaticAnalyzerCheckers
-  clangStaticAnalyzerCore
-  clangFrontendTool
-  clangFrontend
-  clangDriver
-  clangSerialization
-  clangCodeGen
-  clangParse
-  clangSema
-  clangAnalysis
-  clangRewriteFrontend
-  clangRewrite
-  clangAST
-  clangBasic
-  clangEdit
-  clangLex
-  clangARCMigrate
+  clang-cpp
 )
 
 add_executable(clang_delta

--- a/clang_delta/Makefile.am
+++ b/clang_delta/Makefile.am
@@ -127,13 +127,7 @@ clang_delta_CXXFLAGS = \
 # In LLVM 3.5, `llvm-config --ldflags' does not contain the list of system
 # libraries.  So probably, we could move `LLVMLDFLAGS' back to the definition
 # of `clang_delta_LDFLAGS'.  I'll do that later.
-clang_delta_LDADD = \
-	-lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers \
-	-lclangStaticAnalyzerCore \
-	-lclangFrontendTool -lclangFrontend -lclangDriver -lclangSerialization \
-	-lclangCodeGen -lclangParse -lclangSema -lclangAnalysis \
-	-lclangRewriteFrontend -lclangRewrite -lclangAST -lclangBasic -lclangEdit -lclangLex \
-	-lclangARCMigrate \
+clang_delta_LDADD = -lclang-cpp \
 	$(LLVMLIBS) \
 	$(CLANG_LDFLAGS) \
 	$(LLVMLDFLAGS)

--- a/clang_delta/Makefile.in
+++ b/clang_delta/Makefile.in
@@ -575,12 +575,7 @@ clang_delta_CXXFLAGS = \
 # libraries.  So probably, we could move `LLVMLDFLAGS' back to the definition
 # of `clang_delta_LDFLAGS'.  I'll do that later.
 clang_delta_LDADD = \
-	-lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers \
-	-lclangStaticAnalyzerCore \
-	-lclangFrontendTool -lclangFrontend -lclangDriver -lclangSerialization \
-	-lclangCodeGen -lclangParse -lclangSema -lclangAnalysis \
-	-lclangRewriteFrontend -lclangRewrite -lclangAST -lclangBasic -lclangEdit -lclangLex \
-	-lclangARCMigrate \
+	-lclang-cpp \
 	$(LLVMLIBS) \
 	$(CLANG_LDFLAGS) \
 	$(LLVMLDFLAGS)


### PR DESCRIPTION
The change is needed to link clang_delta with LLVM version 9.