### PR TITLE
Make it compile with LLVM11

### DIFF
--- a/clang_delta/CommonRenameClassRewriteVisitor.h
+++ b/clang_delta/CommonRenameClassRewriteVisitor.h
@@ -98,7 +98,7 @@ bool CommonRenameClassRewriteVisitor<T>::VisitUsingDecl(UsingDecl *D)
     return true;
 
   IdentifierInfo *IdInfo = DeclName.getAsIdentifierInfo();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = IdInfo->getName().str();
   std::string Name;
   if (getNewNameByName(IdName, Name)) {
     SourceLocation LocStart = NameInfo.getBeginLoc();
@@ -337,7 +337,7 @@ template<typename T> bool CommonRenameClassRewriteVisitor<T>::
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = IdInfo->getName().str();
   std::string Name;
   if (getNewNameByName(IdName, Name)) {
     SourceLocation LocStart = DTSLoc.getTemplateNameLoc();

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -458,7 +458,7 @@ bool RemoveNamespaceRewriteVisitor::VisitDependentTemplateSpecializationTypeLoc(
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = IdInfo->getName().str();
   std::string Name;
 
   // FIXME:

--- a/clang_delta/RewriteUtils.cpp
+++ b/clang_delta/RewriteUtils.cpp
@@ -748,7 +748,7 @@ std::string RewriteUtils::getStmtIndentString(Stmt *S,
     ++I;
   indentSpace = MB.substr(lineOffs, I-lineOffs);
 
-  return indentSpace;
+  return indentSpace.str();
 }
 
 bool RewriteUtils::addLocalVarToFunc(const std::string &VarStr,

--- a/clang_delta/Transformation.cpp
+++ b/clang_delta/Transformation.cpp
@@ -357,7 +357,7 @@ unsigned int Transformation::getConstArraySize(
   llvm::SmallString<8> IntStr;
   Result.toStringUnsigned(IntStr);
 
-  std::stringstream TmpSS(IntStr.str());
+  std::stringstream TmpSS(IntStr.str().str());
 
   if (!(TmpSS >> Sz)) {
     TransAssert(0 && "Non-integer value!");

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -16,7 +16,9 @@
 
 #include <sstream>
 
+#include "clang/Basic/Builtins.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/FileManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -101,16 +103,16 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
   CompilerInvocation &Invocation = ClangInstance->getInvocation();
   InputKind IK = FrontendOptions::getInputKindForExtension(
         StringRef(SrcFileName).rsplit('.').second);
-  if (IK.getLanguage() == InputKind::C) {
-    Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind::C, T, PPOpts);
+  if (IK.getLanguage() == Language::C) {
+    Invocation.setLangDefaults(ClangInstance->getLangOpts(), Language::C, T, PPOpts);
   }
-  else if (IK.getLanguage() == InputKind::CXX) {
+  else if (IK.getLanguage() == Language::CXX) {
     // ISSUE: it might cause some problems when building AST
     // for a function which has a non-declared callee, e.g.,
     // It results an empty AST for the caller.
-    Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind::CXX, T, PPOpts);
+    Invocation.setLangDefaults(ClangInstance->getLangOpts(), Language::CXX, T, PPOpts);
   }
-  else if(IK.getLanguage() == InputKind::OpenCL) {
+  else if(IK.getLanguage() == Language::OpenCL) {
     //Commandline parameters
     std::vector<const char*> Args;
     Args.push_back("-x");
@@ -122,7 +124,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     ClangInstance->createFileManager();
 
     if(CLCPath != NULL && ClangInstance->hasFileManager() &&
-       ClangInstance->getFileManager().getDirectory(CLCPath, false) != NULL) {
+       ClangInstance->getFileManager().getDirectory(CLCPath, false)) {
         Args.push_back("-I");
         Args.push_back(CLCPath);
     }
@@ -132,10 +134,10 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     Args.push_back("-fno-builtin");
 
     CompilerInvocation::CreateFromArgs(Invocation,
-                                       &Args[0], &Args[0] + Args.size(),
+                                       ArrayRef<const char*>(&Args[0], &Args[0] + Args.size()),
                                        ClangInstance->getDiagnostics());
     Invocation.setLangDefaults(ClangInstance->getLangOpts(),
-                               InputKind::OpenCL, T, PPOpts);
+                               Language::OpenCL, T, PPOpts);
   }
   else {
     ErrorMsg = "Unsupported file type!";


### PR DESCRIPTION
I got a bunch of errors trying to compile creduce from scratch on Ubuntu 16.04.6 with LLVM 11.0.0 (`1:11~++20200524080829+8a5aea7b504-1~exp1~20200524181436.2991`). I'm not sure if this is just because of using LLVM11, but these changes seem make it build for me.

I'm not sending this PR necessarily to have it merged (so feel free to close without merging), but just in case this is useful to anybody. I haven't tried to preserve compatibility with earlier/other versions at all...