### PR TITLE
Compatibility for LLVM 11

### DIFF
--- a/clang_delta/CommonRenameClassRewriteVisitor.h
+++ b/clang_delta/CommonRenameClassRewriteVisitor.h
@@ -98,7 +98,7 @@ bool CommonRenameClassRewriteVisitor<T>::VisitUsingDecl(UsingDecl *D)
     return true;
 
   IdentifierInfo *IdInfo = DeclName.getAsIdentifierInfo();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = std::string(IdInfo->getName());
   std::string Name;
   if (getNewNameByName(IdName, Name)) {
     SourceLocation LocStart = NameInfo.getBeginLoc();
@@ -332,7 +332,7 @@ template<typename T> bool CommonRenameClassRewriteVisitor<T>::
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = std::string(IdInfo->getName());
   std::string Name;
   if (getNewNameByName(IdName, Name)) {
     SourceLocation LocStart = DTSLoc.getTemplateNameLoc();

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -458,7 +458,7 @@ bool RemoveNamespaceRewriteVisitor::VisitDependentTemplateSpecializationTypeLoc(
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
-  std::string IdName = IdInfo->getName();
+  std::string IdName = std::string(IdInfo->getName());
   std::string Name;
 
   // FIXME:

--- a/clang_delta/RewriteUtils.cpp
+++ b/clang_delta/RewriteUtils.cpp
@@ -730,7 +730,7 @@ std::string RewriteUtils::getStmtIndentString(Stmt *S,
     ++I;
   indentSpace = MB.substr(lineOffs, I-lineOffs);
 
-  return indentSpace;
+  return std::string(indentSpace);
 }
 
 bool RewriteUtils::addLocalVarToFunc(const std::string &VarStr,

--- a/clang_delta/Transformation.cpp
+++ b/clang_delta/Transformation.cpp
@@ -356,7 +356,7 @@ unsigned int Transformation::getConstArraySize(
   llvm::SmallString<8> IntStr;
   Result.toStringUnsigned(IntStr);
 
-  std::stringstream TmpSS(IntStr.str());
+  std::stringstream TmpSS(std::string(IntStr.str()));
 
   if (!(TmpSS >> Sz)) {
     TransAssert(0 && "Non-integer value!");

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -16,6 +16,7 @@
 
 #include <sstream>
 
+#include "clang/Basic/Builtins.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/Preprocessor.h"
@@ -101,6 +102,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
   CompilerInvocation &Invocation = ClangInstance->getInvocation();
   InputKind IK = FrontendOptions::getInputKindForExtension(
         StringRef(SrcFileName).rsplit('.').second);
+#if LLVM_VERSION_MAJOR < 10
   if (IK.getLanguage() == InputKind::C) {
     Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind::C, T, PPOpts);
   }
@@ -111,6 +113,18 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind::CXX, T, PPOpts);
   }
   else if(IK.getLanguage() == InputKind::OpenCL) {
+#else
+  if (IK.getLanguage() == Language::C) {
+    Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind(Language::C), T, PPOpts);
+  }
+  else if (IK.getLanguage() == Language::CXX) {
+    // ISSUE: it might cause some problems when building AST
+    // for a function which has a non-declared callee, e.g.,
+    // It results an empty AST for the caller.
+    Invocation.setLangDefaults(ClangInstance->getLangOpts(), InputKind(Language::CXX), T, PPOpts);
+  }
+  else if(IK.getLanguage() == Language::OpenCL) {
+#endif
     //Commandline parameters
     std::vector<const char*> Args;
     Args.push_back("-x");
@@ -122,7 +136,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     ClangInstance->createFileManager();
 
     if(CLCPath != NULL && ClangInstance->hasFileManager() &&
-       ClangInstance->getFileManager().getDirectory(CLCPath, false) != NULL) {
+       ClangInstance->getFileManager().getDirectory(CLCPath, false)) {
         Args.push_back("-I");
         Args.push_back(CLCPath);
     }
@@ -132,10 +146,19 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     Args.push_back("-fno-builtin");
 
     CompilerInvocation::CreateFromArgs(Invocation,
+#if LLVM_VERSION_MAJOR >= 10
+                                       Args,
+#else
                                        &Args[0], &Args[0] + Args.size(),
+#endif
                                        ClangInstance->getDiagnostics());
     Invocation.setLangDefaults(ClangInstance->getLangOpts(),
-                               InputKind::OpenCL, T, PPOpts);
+#if LLVM_VERSION_MAJOR >= 10
+                               InputKind(Language::OpenCL),
+#else
+                               InputKind::OpenCL,
+#endif
+			       T, PPOpts);
   }
   else {
     ErrorMsg = "Unsupported file type!";

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -18,6 +18,7 @@
 
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/FileManager.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Frontend/CompilerInstance.h"


### PR DESCRIPTION
This MR relies on berolinux changes for LLVM 10 support and adds further changes to to LLVM 11.