### PR TITLE
[clang_delta] Fix offset in RemoveBaseClass pass

### DIFF
--- a/clang_delta/RemoveBaseClass.cpp
+++ b/clang_delta/RemoveBaseClass.cpp
@@ -210,6 +210,7 @@ void RemoveBaseClass::copyBaseClassDecls(void)
   SourceLocation StartLoc = TheBaseClass->getBraceRange().getBegin();
   SourceLocation EndLoc = TheBaseClass->getBraceRange().getEnd();
   TransAssert(EndLoc.isValid() && "Invalid RBraceLoc!");
+  StartLoc = StartLoc.getLocWithOffset(1);
   EndLoc = EndLoc.getLocWithOffset(-1);
 
   std::string DeclsStr = 


### PR DESCRIPTION
Without the fix the opening brace of the base class's definition was copied to the derived class together with it's declarations. This resulted in invalid code. For instance

```
class B {
  int a;
};

class D : B {
  int c;
};
```
got transformed into

```
class D  {
  int c;
{
  int a;};
```

With the changes the result is

```
class D  {
  int c;

  int a;};
```

The same changes has also been made for C-Vise: https://github.com/marxin/cvise/blame/9f237d6619f08e85784e5356869f48f81678815f/clang_delta/RemoveBaseClass.cpp#L190