### PR TITLE
Fix hardcoded C++ flag and compatibility with newer llvm versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,18 @@ endif()
 find_package(Clang REQUIRED CONFIG NO_CMAKE_BUILDS_PATH)
 message(STATUS "Using ClangConfig.cmake in ${Clang_DIR}")
 
+# Enable appropriate C++ standard based on LLVM version
+if(LLVM_VERSION_MAJOR LESS 10)
+  set(CMAKE_CXX_STANDARD 11)
+elseif(LLVM_VERSION_MAJOR LESS 16)
+  set(CMAKE_CXX_STANDARD 14)
+else()
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+# Make sure compiler appropriate C++ flags are added
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Locate Perl and check its version.
 #
 include(FindPerl)
@@ -116,12 +128,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
     OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # XXX figure out how to get "-std=c++11 -fno-rtti" from LLVM.  That's how we
   # get those options in the Automake path...
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-rtti -fno-strict-aliasing -Wall -Wextra -Wno-long-long -Wno-unused-parameter -Wno-missing-field-initializers")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-strict-aliasing -Wall -Wextra -Wno-long-long -Wno-unused-parameter -Wno-missing-field-initializers")
   if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
   endif()
   set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 endif()
+
 
 ###############################################################################
 

--- a/clang_delta/RemoveUnusedStructField.cpp
+++ b/clang_delta/RemoveUnusedStructField.cpp
@@ -247,7 +247,11 @@ const Expr *RemoveUnusedStructField::getInitExprFromDesignatedInitExpr(
       }
       else {
         const DesignatedInitExpr::Designator *DS = DIE->getDesignator(0);
+#if LLVM_VERSION_MAJOR >= 17
+        const FieldDecl *CurrFD = DS->getFieldDecl();
+#else
         const FieldDecl *CurrFD = DS->getField();
+#endif
         if ((CurrFD && FD == CurrFD) ||
             (CurrFD == NULL && DS->getFieldName() == FD->getIdentifier())) {
           IsFirstField = (I == 0);


### PR DESCRIPTION
* A minor change to be compatible with LLVM >=17 as well as the older versions
  - credit to @mizvekov for #264
* Avoid hardcoding C++ standard flag via "-std=XX"
  - a newer version of LLVM requires newer C++ standards.
  - based on the llvm version, use specific C++ standards and let cmake add an appropriate flag.

  Otherwise, compiling the master branch with the latest LLVM ends with errors like the following:

```console
[  1%] Building CXX object clang_delta/CMakeFiles/clang_delta.dir/AggregateToScalar.cpp.o
cd /home/kumbhar/workarena/repos/external/creduce/build/clang_delta && /usr/bin/c++ -DHAVE_CONFIG_H -DNDEBUG -I/home/kumbhar/workarena/repos/external/creduce/build -I/home/kumbhar/workarena/repos/external/creduce/clang_delta -I/home/kumbhar/workarena/repos/bbp/spack_upstream/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/llvm-17.0.4-j6r4bktrzjs6x22pxkreb6p2kpogib2j/include -std=c++11 -fno-rtti -fno-strict-aliasing -Wall -Wextra -Wno-long-long -Wno-unused-parameter -Wno-missing-field-initializers -fvisibility-inlines-hidden -O3 -DNDEBUG -O3   -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -MD -MT clang_delta/CMakeFiles/clang_delta.dir/AggregateToScalar.cpp.o -MF CMakeFiles/clang_delta.dir/AggregateToScalar.cpp.o.d -o CMakeFiles/clang_delta.dir/AggregateToScalar.cpp.o -c /home/kumbhar/workarena/repos/external/creduce/clang_delta/AggregateToScalar.cpp
In file included from /home/kumbhar/workarena/repos/bbp/spack_upstream/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/llvm-17.0.4-j6r4bktrzjs6x22pxkreb6p2kpogib2j/include/llvm/ADT/DenseMap.h:17,
                 from /home/kumbhar/workarena/repos/external/creduce/clang_delta/AggregateToScalar.h:16,
                 from /home/kumbhar/workarena/repos/external/creduce/clang_delta/AggregateToScalar.cpp:15:
/home/kumbhar/workarena/repos/bbp/spack_upstream/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/llvm-17.0.4-j6r4bktrzjs6x22pxkreb6p2kpogib2j/include/llvm/ADT/DenseMapInfo.h: In static member function ‘static unsigned int llvm::DenseMapInfo<std::tuple<_Tps ...> >::getHashValueImpl(const Tuple&, std::false_type)’:
/home/kumbhar/workarena/repos/bbp/spack_upstream/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/llvm-17.0.4-j6r4bktrzjs6x22pxkreb6p2kpogib2j/include/llvm/ADT/DenseMapInfo.h:264:26: error: ‘tuple_element_t’ in namespace ‘std’ does not name a template type
  264 |     using EltType = std::tuple_element_t<I, Tuple>;
      |                          ^~~~~~~~~~~~~~~
/home/kumbhar/workarena/repos/bbp/spack_upstream/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/llvm-17.0.4-j6r4bktrzjs6x22pxkreb6p2kpogib2j/include/llvm/ADT/DenseMapInfo.h:264:21: note: ‘std::tuple_element_t’ is only available from C++14 onwards
  264 |     using EltType = std::tuple_element_t<I, Tuple>;
      |                     ^~~
/home/kumbhar/workarena/repos/bbp/spack_upstream/opt/spack/linux-ubuntu22.04-skylake/gcc-11.4.0/llvm-17.0.4-j6r4bktrzjs6x22pxkreb6p2kpogib2j/include/llvm/ADT/DenseMapInfo.h:267:22: error: ‘EltType’ was not declared in this scope
  267 |         DenseMapInfo<EltType>::getHashValue(std::get<I>(values)),
```

superseded #264