### PR TITLE
Compatibility with LLVM 18: backport fixes from cvise

### DIFF
--- a/clang_delta/CMakeLists.txt
+++ b/clang_delta/CMakeLists.txt
@@ -85,9 +85,21 @@ llvm_map_components_to_libnames(LLVM_LIBS
   support
 )
 
-set(CLANG_LIBS
-  clang-cpp
-)
+if (${LLVM_LINK_LLVM_DYLIB})
+  set(CLANG_LIBS
+    clang-cpp
+    LLVM
+  )
+else()
+  set(CLANG_LIBS
+    clangAST
+    clangBasic
+    clangFrontend
+    clangParse
+    clangLex
+    clangRewrite
+  )
+endif()
 
 add_executable(clang_delta
   ${CMAKE_BINARY_DIR}/config.h

--- a/clang_delta/RemoveUnusedFunction.cpp
+++ b/clang_delta/RemoveUnusedFunction.cpp
@@ -215,11 +215,23 @@ bool RUFAnalysisVisitor::VisitFunctionDecl(FunctionDecl *FD)
       FD->getDependentSpecializationInfo();
     // don't need to track all specs, just associate FD with one
     // of those
-    if (Info->getNumTemplates() > 0) {
-      const FunctionDecl *Member =
-        Info->getTemplate(0)->getTemplatedDecl();
-      ConsumerInstance->addOneMemberSpecialization(FD, Member);
+    const FunctionDecl *Member = nullptr;
+
+#if LLVM_VERSION_MAJOR >= 18
+    ArrayRef<FunctionTemplateDecl *> members = Info->getCandidates();
+    if (!members.empty()) {
+      Member = members[0]->getTemplatedDecl();
     }
+#else
+    if (Info->getNumTemplates() > 0) {
+      Member =
+        Info->getTemplate(0)->getTemplatedDecl();
+    }
+#endif
+
+    if (Member != nullptr)
+      ConsumerInstance->addOneMemberSpecialization(FD, Member);
+
     return true;
   }
 
@@ -914,11 +926,21 @@ void RemoveUnusedFunction::handleOneFunctionDecl(const FunctionDecl *TheFD)
       TheFD->getDependentSpecializationInfo();
     // don't need to track all specs, just associate FD with one
     // of those
-    if (Info->getNumTemplates() > 0) {
-      const FunctionDecl *Member =
-        Info->getTemplate(0)->getTemplatedDecl();
-      createFuncToExplicitSpecs(Member);
+    const FunctionDecl *Member = nullptr;
+
+#if LLVM_VERSION_MAJOR >= 18
+    ArrayRef<FunctionTemplateDecl *> members = Info->getCandidates();
+    if (!members.empty()) {
+      Member = members[0]->getTemplatedDecl();
     }
+#else
+    if (Info->getNumTemplates() > 0) {
+      Member = Info->getTemplate(0)->getTemplatedDecl();
+    }
+#endif
+
+    if (Member != nullptr)
+      createFuncToExplicitSpecs(Member);
     return;
   }
 

--- a/clang_delta/ReplaceDependentName.cpp
+++ b/clang_delta/ReplaceDependentName.cpp
@@ -120,8 +120,14 @@ void ReplaceDependentName::handleOneElaboratedTypeLoc(
     return;
 
   const ElaboratedType *ET = TLoc.getTypePtr();
+
+#if LLVM_VERSION_MAJOR >= 18
+  if ((ET->getKeyword() != ElaboratedTypeKeyword::Typename) && (ET->getKeyword() != ElaboratedTypeKeyword::None))
+    return;
+#else
   if ((ET->getKeyword() != ETK_Typename) && (ET->getKeyword() != ETK_None))
     return;
+#endif
 
   if (TLoc.getQualifierLoc().getBeginLoc().isInvalid())
     return;
@@ -155,8 +161,14 @@ void ReplaceDependentName::handleOneDependentNameTypeLoc(
   const DependentNameType *DNT = 
     dyn_cast<DependentNameType>(TLoc.getTypePtr());
   TransAssert(DNT && "NULL DependentNameType!");
+
+#if LLVM_VERSION_MAJOR >= 18
+  if (DNT->getKeyword() != ElaboratedTypeKeyword::Typename)
+    return;
+#else
   if (DNT->getKeyword() != ETK_Typename)
     return;
+#endif
 
   std::string Str = "";
   bool Typename = false;

--- a/clang_delta/ReplaceDependentTypedef.cpp
+++ b/clang_delta/ReplaceDependentTypedef.cpp
@@ -114,7 +114,12 @@ bool ReplaceDependentTypedef::isValidType(const QualType &QT)
   case Type::Elaborated: {
     const ElaboratedType *ETy = dyn_cast<ElaboratedType>(Ty);
     ElaboratedTypeKeyword Keyword = ETy->getKeyword();
+
+#if LLVM_VERSION_MAJOR >= 18
+    return ((Keyword == ElaboratedTypeKeyword::Typename) || (Keyword == ElaboratedTypeKeyword::None));
+#else
     return ((Keyword == ETK_Typename) || (Keyword == ETK_None));
+#endif
   }
   
   default:


### PR DESCRIPTION
* Cherry-picking relevant commits from [cvise project](https://github.com/marxin/cvise/) for LLVM v18 compatibility
* NOTE: change to `clang_delta/CMakeLists.txt` required because I was getting:

```console
pramod@perfeng:~/repos/external/creduce/build/clang_delta$ /usr/bin/c++  -fno-rtti -fno-strict-aliasing -Wall -Wextra -Wno-long-long -Wno-unused-parameter -Wno-missing-field-initializers -fvisibility-inlines-hidden -rdynamic CMakeFiles/clang_delta.dir/AggregateToScalar.cpp.o CMakeFiles/clang_delta.dir/BinOpSimplification.cpp.o CMakeFiles/clang_delta.dir/CallExprToValue.cpp.o CMakeFiles/clang_delta.dir/ClangDelta.cpp.o CMakeFiles/clang_delta.dir/ClassTemplateToClass.cpp.o CMakeFiles/clang_delta.dir/CombineGlobalVarDecl.cpp.o CMakeFiles/clang_delta.dir/CombineLocalVarDecl.cpp.o CMakeFiles/clang_delta.dir/CopyPropagation.cpp.o CMakeFiles/clang_delta.dir/EmptyStructToInt.cpp.o CMakeFiles/clang_delta.dir/ExpressionDetector.cpp.o CMakeFiles/clang_delta.dir/InstantiateTemplateParam.cpp.o CMakeFiles/clang_delta.dir/InstantiateTemplateTypeParamToInt.cpp.o CMakeFiles/clang_delta.dir/LiftAssignmentExpr.cpp.o CMakeFiles/clang_delta.dir/LocalToGlobal.cpp.o CMakeFiles/clang_delta.dir/MoveFunctionBody.cpp.o CMakeFiles/clang_delta.dir/MoveGlobalVar.cpp.o CMakeFiles/clang_delta.dir/ParamToGlobal.cpp.o CMakeFiles/clang_delta.dir/ParamToLocal.cpp.o CMakeFiles/clang_delta.dir/ReduceArrayDim.cpp.o CMakeFiles/clang_delta.dir/ReduceArraySize.cpp.o CMakeFiles/clang_delta.dir/ReduceClassTemplateParameter.cpp.o CMakeFiles/clang_delta.dir/ReducePointerLevel.cpp.o CMakeFiles/clang_delta.dir/ReducePointerPairs.cpp.o CMakeFiles/clang_delta.dir/RemoveAddrTaken.cpp.o CMakeFiles/clang_delta.dir/RemoveArray.cpp.o CMakeFiles/clang_delta.dir/RemoveBaseClass.cpp.o CMakeFiles/clang_delta.dir/RemoveCtorInitializer.cpp.o CMakeFiles/clang_delta.dir/RemoveEnumMemberValue.cpp.o CMakeFiles/clang_delta.dir/RemoveNamespace.cpp.o CMakeFiles/clang_delta.dir/RemoveNestedFunction.cpp.o CMakeFiles/clang_delta.dir/RemovePointer.cpp.o CMakeFiles/clang_delta.dir/RemoveTrivialBaseTemplate.cpp.o CMakeFiles/clang_delta.dir/RemoveUnresolvedBase.cpp.o CMakeFiles/clang_delta.dir/RemoveUnusedEnumMember.cpp.o CMakeFiles/clang_delta.dir/RemoveUnusedFunction.cpp.o CMakeFiles/clang_delta.dir/RemoveUnusedOuterClass.cpp.o CMakeFiles/clang_delta.dir/RemoveUnusedStructField.cpp.o CMakeFiles/clang_delta.dir/RemoveUnusedVar.cpp.o CMakeFiles/clang_delta.dir/RenameCXXMethod.cpp.o CMakeFiles/clang_delta.dir/RenameClass.cpp.o CMakeFiles/clang_delta.dir/RenameFun.cpp.o CMakeFiles/clang_delta.dir/RenameParam.cpp.o CMakeFiles/clang_delta.dir/RenameVar.cpp.o CMakeFiles/clang_delta.dir/ReplaceArrayAccessWithIndex.cpp.o CMakeFiles/clang_delta.dir/ReplaceArrayIndexVar.cpp.o CMakeFiles/clang_delta.dir/ReplaceCallExpr.cpp.o CMakeFiles/clang_delta.dir/ReplaceClassWithBaseTemplateSpec.cpp.o CMakeFiles/clang_delta.dir/ReplaceDependentName.cpp.o CMakeFiles/clang_delta.dir/ReplaceDependentTypedef.cpp.o CMakeFiles/clang_delta.dir/ReplaceDerivedClass.cpp.o CMakeFiles/clang_delta.dir/ReplaceFunctionDefWithDecl.cpp.o CMakeFiles/clang_delta.dir/ReplaceOneLevelTypedefType.cpp.o CMakeFiles/clang_delta.dir/ReplaceSimpleTypedef.cpp.o CMakeFiles/clang_delta.dir/ReplaceUndefinedFunction.cpp.o CMakeFiles/clang_delta.dir/ReturnVoid.cpp.o CMakeFiles/clang_delta.dir/RewriteUtils.cpp.o CMakeFiles/clang_delta.dir/SimpleInliner.cpp.o CMakeFiles/clang_delta.dir/SimplifyCallExpr.cpp.o CMakeFiles/clang_delta.dir/SimplifyCommaExpr.cpp.o CMakeFiles/clang_delta.dir/SimplifyDependentTypedef.cpp.o CMakeFiles/clang_delta.dir/SimplifyIf.cpp.o CMakeFiles/clang_delta.dir/SimplifyNestedClass.cpp.o CMakeFiles/clang_delta.dir/SimplifyRecursiveTemplateInstantiation.cpp.o CMakeFiles/clang_delta.dir/SimplifyStruct.cpp.o CMakeFiles/clang_delta.dir/SimplifyStructUnionDecl.cpp.o CMakeFiles/clang_delta.dir/TemplateArgToInt.cpp.o CMakeFiles/clang_delta.dir/TemplateNonTypeArgToInt.cpp.o CMakeFiles/clang_delta.dir/Transformation.cpp.o CMakeFiles/clang_delta.dir/TransformationManager.cpp.o CMakeFiles/clang_delta.dir/UnifyFunctionDecl.cpp.o CMakeFiles/clang_delta.dir/UnionToStruct.cpp.o CMakeFiles/clang_delta.dir/VectorToArray.cpp.o CMakeFiles/clang_delta.dir/git_version.cpp.o -o clang_delta   -L/usr/lib/llvm-18/lib  -Wl,-rpath,/usr/lib/llvm-18/lib /usr/lib/llvm-18/lib/libclang-cpp.so.18 -Wl,-rpath-link,/usr/lib/llvm-18/lib -lLLVMSupport
/usr/bin/ld: CMakeFiles/clang_delta.dir/TransformationManager.cpp.o: undefined reference to symbol '_ZN4llvm6TripleC1ERKNS_5TwineE@@LLVM_18'
/usr/bin/ld: /usr/lib/llvm-18/lib/libLLVM-18.so.1: error adding symbols: DSO missing from command line
```

In combination with #270, locally I can build everything with LLVM 18:

```console
$ cmake .. -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm -DCMAKE_INSTALL_PREFIX=$HOME/creduce-llvm18
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test HAVE_FFI_CALL
-- Performing Test HAVE_FFI_CALL - Success
-- Found FFI: /usr/lib/x86_64-linux-gnu/libffi.so
-- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
-- Performing Test Terminfo_LINKABLE
-- Performing Test Terminfo_LINKABLE - Success
-- Found Terminfo: /usr/lib/x86_64-linux-gnu/libtinfo.so
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11")
-- Could NOT find zstd (missing: zstd_LIBRARY zstd_INCLUDE_DIR)
-- Found LibXml2: /usr/lib/x86_64-linux-gnu/libxml2.so (found version "2.9.13")
-- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
-- Found LLVM 18.0.0
-- Using LLVMConfig.cmake in /usr/lib/llvm-18/lib/cmake/llvm
-- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
-- Could NOT find zstd (missing: zstd_LIBRARY zstd_INCLUDE_DIR)
-- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
-- Using ClangConfig.cmake in /usr/lib/cmake/clang-18
-- Found Perl: /usr/bin/perl (found version "5.34.0")
-- Found FLEX: /usr/bin/flex (found version "2.6.4")
-- Looking for dlfcn.h
-- Looking for dlfcn.h - found
-- Looking for inttypes.h
-- Looking for inttypes.h - found
-- Looking for memory.h
-- Looking for memory.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stdlib.h
-- Looking for stdlib.h - found
-- Looking for strings.h
-- Looking for strings.h - found
-- Looking for string.h
-- Looking for string.h - found
-- Looking for sys/stat.h
-- Looking for sys/stat.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Performing Test SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG
-- Performing Test SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kumbhar/workarena/repos/external/creduce/build_llvm18

$ make -j && make install
$ $HOME/creduce-llvm18/bin/creduce --version
creduce 2.11.0 (95cb7e1)
```

I am trying to get [creduce up to date](https://github.com/spack/spack/pull/41258) with HPC package manager Spack and hence it would be great if we could have these two PRs merged soon.

Thank you in advance!