### PR TITLE
Add -rpath config to handle case where LLVM libraries are not install…

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -343,6 +343,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/clang_delta/Makefile.am
+++ b/clang_delta/Makefile.am
@@ -99,6 +99,7 @@ LLVMLDFLAGS	:= $(shell "$(LLVM_CONFIG)" \--ldflags)
 LLVMINCLUDEDIR	:= $(shell "$(LLVM_CONFIG)" --includedir)
 LLVMLIBS	:= $(shell "$(LLVM_CONFIG)" \--libs) \
 		   $(shell "$(LLVM_CONFIG)" \--system-libs)
+LLVMLIBDIR	:= $(shell "$(LLVM_CONFIG)" \--prefix)/lib/
 
 clang_delta_CPPFLAGS = \
 	$(CLANG_CPPFLAGS) \
@@ -108,8 +109,9 @@ clang_delta_CXXFLAGS = \
 	$(LLVMCXXFLAGS)
 
 # See comment below about `clang_delta_LDADD' and `LLVMLDFLAGS'.
-# clang_delta_LDFLAGS = \
-#	$(LLVMLDFLAGS)
+clang_delta_LDFLAGS = \
+	$(LLVMLDFLAGS) \
+	-Wl,-rpath=$(LLVMLIBDIR)
 
 # Try to do the "right thing" by putting these in `clang_delta_LDADD' instead
 # of `clang_delta_LDFLAGS'.  This leads to the funny escape in `LLVMLIBS',

--- a/clang_delta/Makefile.in
+++ b/clang_delta/Makefile.in
@@ -194,7 +194,7 @@ am__v_lt_0 = --silent
 am__v_lt_1 = 
 clang_delta_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CXXLD) $(clang_delta_CXXFLAGS) \
-	$(CXXFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
+	$(CXXFLAGS) $(clang_delta_LDFLAGS) $(LDFLAGS) -o $@
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
 am__v_P_0 = false
@@ -471,6 +471,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@
@@ -546,6 +547,7 @@ LLVMINCLUDEDIR := $(shell "$(LLVM_CONFIG)" --includedir)
 LLVMLIBS := $(shell "$(LLVM_CONFIG)" \--libs) \
 		   $(shell "$(LLVM_CONFIG)" \--system-libs)
 
+LLVMLIBDIR := $(shell "$(LLVM_CONFIG)" \--prefix)/lib/
 clang_delta_CPPFLAGS = \
 	$(CLANG_CPPFLAGS) \
 	-I"$(LLVMINCLUDEDIR)/clang"
@@ -555,8 +557,10 @@ clang_delta_CXXFLAGS = \
 
 
 # See comment below about `clang_delta_LDADD' and `LLVMLDFLAGS'.
-# clang_delta_LDFLAGS = \
-#	$(LLVMLDFLAGS)
+clang_delta_LDFLAGS = \
+	$(LLVMLDFLAGS) \
+	-Wl,-rpath=$(LLVMLIBDIR)
+
 
 # Try to do the "right thing" by putting these in `clang_delta_LDADD' instead
 # of `clang_delta_LDFLAGS'.  This leads to the funny escape in `LLVMLIBS',

--- a/clex/Makefile.in
+++ b/clex/Makefile.in
@@ -320,6 +320,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/configure
+++ b/configure
@@ -753,6 +753,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -845,6 +846,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1097,6 +1099,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1234,7 +1245,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1387,6 +1398,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/creduce/Makefile.in
+++ b/creduce/Makefile.in
@@ -287,6 +287,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/delta/Makefile.in
+++ b/delta/Makefile.in
@@ -315,6 +315,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/scripts/Makefile.in
+++ b/scripts/Makefile.in
@@ -256,6 +256,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -258,6 +258,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@

--- a/unifdef/Makefile.in
+++ b/unifdef/Makefile.in
@@ -305,6 +305,7 @@ pdfdir = @pdfdir@
 prefix = @prefix@
 program_transform_name = @program_transform_name@
 psdir = @psdir@
+runstatedir = @runstatedir@
 sbindir = @sbindir@
 sharedstatedir = @sharedstatedir@
 srcdir = @srcdir@


### PR DESCRIPTION
…ed on a system path

If I supply a path to an LLVM installation with `./configure --with-llvm="$HOME/llvm-18/" --disable-trans-assert --cache=.cache --prefix="$HOME/creduce-install/"`, the built `clang_delta` binary's dynamic linkage to `libclang-cpp.so` is broken. 

This patch adds `-rpath` to the linker flags for `clang_delta`. After the change, I ran
```
./bootstrap
./configure --with-llvm="$HOME/llvm-18/" --disable-trans-assert --cache=.cache --prefix="$HOME/creduce-install/"
make -j $(nproc)
make install
```
And ran `ldd clang_delta`
```
clang_delta:
        linux-vdso.so.1 (0x00007ffda37da000)
        libclang-cpp.so.18rc => /home/ych/llvm-18/lib/libclang-cpp.so.18rc (0x00007fec2ec00000)
        libm.so.6 => /lib64/libm.so.6 (0x00007fec2eb25000)
        libz.so.1 => /lib64/libz.so.1 (0x00007fec38be6000)
        libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007fec2eaf5000)
        libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007fec2e800000)
        libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fec2eada000)
        libc.so.6 => /lib64/libc.so.6 (0x00007fec2e400000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fec3a36b000)
```