### PR TITLE
Remove uses of ClassTemplateSpecializationDecl::getTypeAsWritten

### DIFF
--- a/clang_delta/CommonRenameClassRewriteVisitor.h
+++ b/clang_delta/CommonRenameClassRewriteVisitor.h
@@ -144,11 +144,7 @@ bool CommonRenameClassRewriteVisitor<T>::
 
   std::string Name;
   if (getNewName(CXXRD, Name)) {
-    const TypeSourceInfo *TyInfo = D->getTypeAsWritten();
-    if (!TyInfo)
-      return true;
-    TypeLoc TyLoc = TyInfo->getTypeLoc();
-    SourceLocation LocStart = TyLoc.getBeginLoc();
+    SourceLocation LocStart = D->getLocation();
     TransAssert(LocStart.isValid() && "Invalid Location!");
     TheRewriter->ReplaceText(LocStart, CXXRD->getNameAsString().size(), Name);
   }

--- a/clang_delta/CommonRenameClassRewriteVisitor.h
+++ b/clang_delta/CommonRenameClassRewriteVisitor.h
@@ -57,9 +57,6 @@ public:
   bool VisitDependentTemplateSpecializationTypeLoc(
          DependentTemplateSpecializationTypeLoc DTSLoc);
 
-  bool VisitClassTemplatePartialSpecializationDecl(
-         ClassTemplatePartialSpecializationDecl *D);
-
   bool VisitClassTemplateSpecializationDecl(
          ClassTemplateSpecializationDecl *TSD);
 
@@ -122,35 +119,6 @@ bool CommonRenameClassRewriteVisitor<T>::TraverseConstructorInitializer(
   return true;
 }
 
-template<typename T> 
-bool CommonRenameClassRewriteVisitor<T>::
-     VisitClassTemplatePartialSpecializationDecl(
-       ClassTemplatePartialSpecializationDecl *D)
-{
-  const Type *Ty = D->getInjectedSpecializationType().getTypePtr();
-  TransAssert(Ty && "Bad TypePtr!");
-  const TemplateSpecializationType *TST = 
-    dyn_cast<TemplateSpecializationType>(Ty);
-  TransAssert(TST && "Bad TemplateSpecializationType!");
-
-  TemplateName TplName = TST->getTemplateName();
-  const TemplateDecl *TplD = TplName.getAsTemplateDecl();
-  TransAssert(TplD && "Invalid TemplateDecl!");
-  NamedDecl *ND = TplD->getTemplatedDecl();
-  TransAssert(ND && "Invalid NamedDecl!");
-
-  const CXXRecordDecl *CXXRD = dyn_cast<CXXRecordDecl>(ND);
-  TransAssert(CXXRD && "Invalid CXXRecordDecl!");
-
-  std::string Name;
-  if (getNewName(CXXRD, Name)) {
-    SourceLocation LocStart = D->getLocation();
-    TransAssert(LocStart.isValid() && "Invalid Location!");
-    TheRewriter->ReplaceText(LocStart, CXXRD->getNameAsString().size(), Name);
-  }
-  return true;
-}
-
 // ISSUE: I am not sure why, but RecursiveASTVisitor doesn't recursively
 // visit base classes from explicit template specialization, e.g.,
 //   struct A { };
@@ -162,14 +130,24 @@ template<typename T>
 bool CommonRenameClassRewriteVisitor<T>::VisitClassTemplateSpecializationDecl(
        ClassTemplateSpecializationDecl *TSD)
 {
-  if (!TSD->isExplicitSpecialization() || !TSD->isCompleteDefinition())
+  if (!TSD->isExplicitInstantiationOrSpecialization())
     return true;
 
-  for (CXXRecordDecl::base_class_const_iterator I = TSD->bases_begin(),
-       E = TSD->bases_end(); I != E; ++I) {
-    TypeSourceInfo *TSI = (*I).getTypeSourceInfo();
-    TransAssert(TSI && "Bad TypeSourceInfo!");
-    getDerived().TraverseTypeLoc(TSI->getTypeLoc());
+  const CXXRecordDecl *CXXRD = TSD->getSpecializedTemplate()->getTemplatedDecl();
+  std::string Name;
+  if (getNewName(CXXRD, Name)) {
+    SourceLocation LocStart = TSD->getLocation();
+    TransAssert(LocStart.isValid() && "Invalid Location!");
+    TheRewriter->ReplaceText(LocStart, CXXRD->getNameAsString().size(), Name);
+  }
+
+  if (TSD->isExplicitSpecialization() && TSD->isCompleteDefinition()) {
+    for (CXXRecordDecl::base_class_const_iterator I = TSD->bases_begin(),
+         E = TSD->bases_end(); I != E; ++I) {
+      TypeSourceInfo *TSI = (*I).getTypeSourceInfo();
+      TransAssert(TSI && "Bad TypeSourceInfo!");
+      getDerived().TraverseTypeLoc(TSI->getTypeLoc());
+    }
   }
   return true;
 }

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -439,11 +439,7 @@ bool RemoveNamespaceRewriteVisitor::VisitClassTemplatePartialSpecializationDecl(
 
   std::string Name;
   if (ConsumerInstance->getNewName(CXXRD, Name)) {
-    const TypeSourceInfo *TyInfo = D->getTypeAsWritten();
-    if (!TyInfo)
-      return true;
-    TypeLoc TyLoc = TyInfo->getTypeLoc();
-    SourceLocation LocStart = TyLoc.getBeginLoc();
+    SourceLocation LocStart = D->getLocation();
     TransAssert(LocStart.isValid() && "Invalid Location!");
     ConsumerInstance->TheRewriter.ReplaceText(
       LocStart, CXXRD->getNameAsString().size(), Name);

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -91,9 +91,6 @@ public:
   bool VisitTemplateSpecializationTypeLoc(
          TemplateSpecializationTypeLoc TSPLoc);
 
-  bool VisitClassTemplatePartialSpecializationDecl(
-         ClassTemplatePartialSpecializationDecl *D);
-
   bool VisitDependentTemplateSpecializationTypeLoc(
          DependentTemplateSpecializationTypeLoc DTSLoc);
 
@@ -132,14 +129,25 @@ bool RemoveNamespaceASTVisitor::VisitNamespaceDecl(NamespaceDecl *ND)
 bool RemoveNamespaceRewriteVisitor::VisitClassTemplateSpecializationDecl(
        ClassTemplateSpecializationDecl *TSD)
 {
-  if (!TSD->isExplicitSpecialization() || !TSD->isCompleteDefinition())
+  if (!TSD->isExplicitInstantiationOrSpecialization())
     return true;
 
-  for (CXXRecordDecl::base_class_const_iterator I = TSD->bases_begin(),
-       E = TSD->bases_end(); I != E; ++I) {
-    TypeSourceInfo *TSI = (*I).getTypeSourceInfo();
-    TransAssert(TSI && "Bad TypeSourceInfo!");
-    TraverseTypeLoc(TSI->getTypeLoc());
+  const CXXRecordDecl *CXXRD = TSD->getSpecializedTemplate()->getTemplatedDecl();
+  std::string Name;
+  if (ConsumerInstance->getNewName(CXXRD, Name)) {
+    SourceLocation LocStart = TSD->getLocation();
+    TransAssert(LocStart.isValid() && "Invalid Location!");
+    ConsumerInstance->TheRewriter.ReplaceText(
+      LocStart, CXXRD->getNameAsString().size(), Name);
+  }
+
+  if (TSD->isExplicitSpecialization() && TSD->isCompleteDefinition()) {
+    for (CXXRecordDecl::base_class_const_iterator I = TSD->bases_begin(),
+         E = TSD->bases_end(); I != E; ++I) {
+      TypeSourceInfo *TSI = (*I).getTypeSourceInfo();
+      TransAssert(TSI && "Bad TypeSourceInfo!");
+      TraverseTypeLoc(TSI->getTypeLoc());
+    }
   }
   return true;
 }
@@ -416,34 +424,6 @@ bool RemoveNamespaceRewriteVisitor::VisitTemplateSpecializationTypeLoc(
       LocStart, CXXRD->getNameAsString().size(), Name);
   }
 
-  return true;
-}
-
-bool RemoveNamespaceRewriteVisitor::VisitClassTemplatePartialSpecializationDecl(
-       ClassTemplatePartialSpecializationDecl *D)
-{
-  const Type *Ty = D->getInjectedSpecializationType().getTypePtr();
-  TransAssert(Ty && "Bad TypePtr!");
-  const TemplateSpecializationType *TST =
-    dyn_cast<TemplateSpecializationType>(Ty);
-  TransAssert(TST && "Bad TemplateSpecializationType!");
-
-  TemplateName TplName = TST->getTemplateName();
-  const TemplateDecl *TplD = TplName.getAsTemplateDecl();
-  TransAssert(TplD && "Invalid TemplateDecl!");
-  NamedDecl *ND = TplD->getTemplatedDecl();
-  TransAssert(ND && "Invalid NamedDecl!");
-
-  const CXXRecordDecl *CXXRD = dyn_cast<CXXRecordDecl>(ND);
-  TransAssert(CXXRD && "Invalid CXXRecordDecl!");
-
-  std::string Name;
-  if (ConsumerInstance->getNewName(CXXRD, Name)) {
-    SourceLocation LocStart = D->getLocation();
-    TransAssert(LocStart.isValid() && "Invalid Location!");
-    ConsumerInstance->TheRewriter.ReplaceText(
-      LocStart, CXXRD->getNameAsString().size(), Name);
-  }
   return true;
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/91393 removed `ClassTemplateSpecializationDecl::getTypeAsWritten`. This was used to get the `SourceLocation` for the name of a `ClassTemplatePartialSpecializationDecl` in a few places, which is the same `SourceLocation` returned by `Decl::getLocation`. This fix should be backwards compatible. 

The removal of `getTypeAsWritten` also means that there no longer exists a `TemplateSpecializationTypeLoc` to be traversed by `RecursiveASTVisitor`, so this PR also includes a commit which ensures that explicit specializations/instantiations are correctly renamed.

See also https://github.com/marxin/cvise/issues/142.