### PR TITLE
Add tests for replace-dependent-typedef

### DIFF
--- a/clang_delta/Makefile.am
+++ b/clang_delta/Makefile.am
@@ -419,6 +419,7 @@ EXTRA_DIST = \
 	tests/rename-fun/test1.h \
 	tests/rename-param/invalid.c \
 	tests/rename-var/rename-var.c \
+	tests/replace-dependent-typedef/test1.cc \
 	tests/replace-derived-class/replace-derived1.cpp \
 	tests/replace-derived-class/replace-derived2.cpp \
 	tests/replace-derived-class/replace-derived3.cpp \

--- a/clang_delta/Makefile.in
+++ b/clang_delta/Makefile.in
@@ -866,6 +866,7 @@ EXTRA_DIST = \
 	tests/rename-fun/test1.h \
 	tests/rename-param/invalid.c \
 	tests/rename-var/rename-var.c \
+	tests/replace-dependent-typedef/test1.cc \
 	tests/replace-derived-class/replace-derived1.cpp \
 	tests/replace-derived-class/replace-derived2.cpp \
 	tests/replace-derived-class/replace-derived3.cpp \

--- a/clang_delta/tests/replace-dependent-typedef/test1.cc
+++ b/clang_delta/tests/replace-dependent-typedef/test1.cc
@@ -1,0 +1,19 @@
+// RUN: %clang_delta --transformation=replace-dependent-typedef --counter=1 %s 2>&1 | %remove_lit_checks | FileCheck %s --check-prefix=CHECK-1
+// RUN: %clang_delta --transformation=replace-dependent-typedef --counter=2 %s 2>&1 | %remove_lit_checks | FileCheck %s --check-prefix=CHECK-2
+// RUN: %clang_delta --transformation=replace-dependent-typedef --counter=3 %s 2>&1 | %remove_lit_checks | FileCheck %s --check-prefix=CHECK-3
+
+typedef long xx_t;
+// CHECK-1: typedef long xx;
+typedef xx_t xx;
+
+template <class T> struct S { typedef T type; };
+struct A { };
+// CHECK-2: struct B { typedef A type; };
+struct B { typedef S<A>::type type; };
+
+template <typename T>
+struct C {
+  typedef int Inner;
+  // CHECK-3: typedef int Bar;
+  typedef C::Inner Bar;
+};


### PR DESCRIPTION
Add a few basic test cases for the "pass_clang"
"replace-dependent-typedef" pass.

This is in preparation for #279.