### PR TITLE
Skip non-dep typedefs in replace-dependent-typedef

### DIFF
--- a/clang_delta/Makefile.am
+++ b/clang_delta/Makefile.am
@@ -419,6 +419,7 @@ EXTRA_DIST = \
 	tests/rename-fun/test1.h \
 	tests/rename-param/invalid.c \
 	tests/rename-var/rename-var.c \
+	tests/replace-dependent-typedef/test2.cc \
 	tests/replace-derived-class/replace-derived1.cpp \
 	tests/replace-derived-class/replace-derived2.cpp \
 	tests/replace-derived-class/replace-derived3.cpp \

--- a/clang_delta/Makefile.in
+++ b/clang_delta/Makefile.in
@@ -866,6 +866,7 @@ EXTRA_DIST = \
 	tests/rename-fun/test1.h \
 	tests/rename-param/invalid.c \
 	tests/rename-var/rename-var.c \
+	tests/replace-dependent-typedef/test2.cc \
 	tests/replace-derived-class/replace-derived1.cpp \
 	tests/replace-derived-class/replace-derived2.cpp \
 	tests/replace-derived-class/replace-derived3.cpp \

--- a/clang_delta/ReplaceDependentTypedef.cpp
+++ b/clang_delta/ReplaceDependentTypedef.cpp
@@ -45,6 +45,53 @@ It also tries to reduce the typedef chain, e.g. \n\
 static RegisterTransformation<ReplaceDependentTypedef>
          Trans("replace-dependent-typedef", DescriptionMsg);
 
+namespace {
+
+bool DependsOnTypedef(const Type &Ty) {
+  switch (Ty.getTypeClass()) {
+  case Type::SubstTemplateTypeParm: {
+    const SubstTemplateTypeParmType *TP =
+      dyn_cast<SubstTemplateTypeParmType>(&Ty);
+    const Type *ReplTy = TP->getReplacementType().getTypePtr();
+    return DependsOnTypedef(*ReplTy);
+  }
+
+  case Type::Elaborated: {
+    const ElaboratedType *ETy = dyn_cast<ElaboratedType>(&Ty);
+    const Type *NamedTy = ETy->getNamedType().getTypePtr();
+    return DependsOnTypedef(*NamedTy);
+  }
+
+  case Type::Typedef: {
+    return true;
+  }
+
+  case Type::DependentName: {
+    const DependentNameType *DNT = dyn_cast<DependentNameType>(&Ty);
+    const NestedNameSpecifier *Specifier = DNT->getQualifier();
+    if (!Specifier)
+      return false;
+    const Type *NestedTy = Specifier->getAsType();
+    if (!NestedTy)
+      return false;
+    return DependsOnTypedef(*NestedTy);
+  }
+
+  case Type::Record:
+  case Type::Builtin: { // fall-through
+    return false;
+  }
+
+  default:
+    return false;
+  }
+
+  TransAssert(0 && "Unreachable code!");
+  return false;
+}
+
+}  // namespace
+
 class ReplaceDependentTypedefCollectionVisitor : public
   RecursiveASTVisitor<ReplaceDependentTypedefCollectionVisitor> {
 
@@ -136,6 +183,8 @@ void ReplaceDependentTypedef::handleOneTypedefDecl(const TypedefDecl *D)
     return;
 
   if (!isValidType(D->getUnderlyingType()))
+    return;
+  if (!DependsOnTypedef(*D->getUnderlyingType()))
     return;
 
   std::string Str = "";

--- a/clang_delta/tests/replace-dependent-typedef/test2.cc
+++ b/clang_delta/tests/replace-dependent-typedef/test2.cc
@@ -1,0 +1,25 @@
+// RUN: %clang_delta --query-instances=replace-dependent-typedef %s 2>&1 | %remove_lit_checks | FileCheck %s --check-prefix=CHECK-CNT
+// RUN: %clang_delta --transformation=replace-dependent-typedef --counter=1 %s 2>&1 | %remove_lit_checks | FileCheck %s --check-prefix=CHECK-1
+
+template <typename T>
+struct A {
+  struct Inner;
+  // This shouldn't be treated as an instance:
+  typedef A::Inner Foo;
+};
+
+template <class T> struct S { typedef T type; };
+
+struct B {
+  struct Inner;
+};
+
+template <typename T>
+struct C {
+  typedef typename S<T>::type::Inner Bar;
+};
+
+// CHECK-1: typedef B::Inner D;
+typedef C<B>::Bar D;
+
+// CHECK-CNT: Available transformation instances: 1


### PR DESCRIPTION
Only consider typedefs that depend on other typedefs in replace-dependent-typedef.

This prevents the pass from reporting a success when no actual change has been made, like in the case when a typedef belongs to and refers to a template struct (where multiple possible string representations may confuse the checks).

This fixes #279.