### PR TITLE
clang-21 support

### DIFF
--- a/clang_delta/CommonRenameClassRewriteVisitor.h
+++ b/clang_delta/CommonRenameClassRewriteVisitor.h
@@ -310,7 +310,11 @@ template<typename T> bool CommonRenameClassRewriteVisitor<T>::
     dyn_cast<DependentTemplateSpecializationType>(Ty);
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
+#if LLVM_VERSION_MAJOR >= 21
+  const IdentifierInfo *IdInfo = DTST->getDependentTemplateName().getName().getIdentifier();
+#else
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
+#endif
   std::string IdName = IdInfo->getName().str();
   std::string Name;
   if (getNewNameByName(IdName, Name)) {

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -566,8 +566,10 @@ bool RemoveNamespaceRewriteVisitor::TraverseNestedNameSpecifierLoc(
           ND = NAD->getNamespace()->getCanonicalDecl();
         break;
       }
-      case NestedNameSpecifier::TypeSpec: // Fall-through
-      case NestedNameSpecifier::TypeSpecWithTemplate:
+#if LLVM_VERSION_MAJOR < 21
+      case NestedNameSpecifier::TypeSpecWithTemplate: // Fall-through
+#endif
+      case NestedNameSpecifier::TypeSpec:
         TraverseTypeLoc(Loc.getTypeLoc());
         break;
       default:

--- a/clang_delta/RemoveNamespace.cpp
+++ b/clang_delta/RemoveNamespace.cpp
@@ -440,7 +440,11 @@ bool RemoveNamespaceRewriteVisitor::VisitDependentTemplateSpecializationTypeLoc(
     dyn_cast<DependentTemplateSpecializationType>(Ty);
   TransAssert(DTST && "Bad DependentTemplateSpecializationType!");
 
+#if LLVM_VERSION_MAJOR >= 21
+  const IdentifierInfo *IdInfo = DTST->getDependentTemplateName().getName().getIdentifier();
+#else
   const IdentifierInfo *IdInfo = DTST->getIdentifier();
+#endif
   std::string IdName = IdInfo->getName().str();
   std::string Name;
 

--- a/clang_delta/RemoveUnusedFunction.cpp
+++ b/clang_delta/RemoveUnusedFunction.cpp
@@ -254,7 +254,11 @@ bool RUFAnalysisVisitor::VisitFunctionDecl(FunctionDecl *FD)
 
   if (FD->isReferenced() ||
       FD->isMain() ||
+#if LLVM_VERSION_MAJOR >= 21
+      FD->hasAttr<DeviceKernelAttr>() ||
+#else
       FD->hasAttr<OpenCLKernelAttr>() ||
+#endif
       ConsumerInstance->hasReferencedSpecialization(CanonicalFD) ||
       ConsumerInstance->isInlinedSystemFunction(CanonicalFD) ||
       ConsumerInstance->isInReferencedSet(CanonicalFD) ||

--- a/clang_delta/RenameFun.cpp
+++ b/clang_delta/RenameFun.cpp
@@ -261,7 +261,11 @@ void RenameFun::addFun(const FunctionDecl *FD)
 {
   std::string Name = FD->getNameAsString();
   // Skip special functions
+#if LLVM_VERSION_MAJOR >= 21
+  if (isSpecialFun(Name) || FD->hasAttr<DeviceKernelAttr>())
+#else
   if (isSpecialFun(Name) || FD->hasAttr<OpenCLKernelAttr>())
+#endif
     FunToNameMap[FD] = Name;
 
   if (FunToNameMap.find(FD) != FunToNameMap.end())

--- a/clang_delta/Transformation.cpp
+++ b/clang_delta/Transformation.cpp
@@ -635,8 +635,10 @@ const DeclContext *Transformation::getDeclContextFromSpecifier(
         const NamespaceAliasDecl *NAD = NNS->getAsNamespaceAlias();
         return NAD->getNamespace()->getCanonicalDecl();
       }
-      case NestedNameSpecifier::TypeSpec: // Fall-through
-      case NestedNameSpecifier::TypeSpecWithTemplate: {
+#if LLVM_VERSION_MAJOR < 21
+      case NestedNameSpecifier::TypeSpecWithTemplate: // Fall-through
+#endif
+      case NestedNameSpecifier::TypeSpec: {
         const Type *Ty = NNS->getAsType();
         if (const RecordType *RT = Ty->getAs<RecordType>())
           return RT->getDecl();

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -125,7 +125,7 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
     ClangInstance->createFileManager();
 
     if(CLCPath != NULL && ClangInstance->hasFileManager() &&
-       ClangInstance->getFileManager().getDirectory(CLCPath, false)) {
+       ClangInstance->getFileManager().getOptionalDirectoryRef(CLCPath, false)) {
         Args.push_back("-I");
         Args.push_back(CLCPath);
     }

--- a/clang_delta/TransformationManager.cpp
+++ b/clang_delta/TransformationManager.cpp
@@ -146,8 +146,13 @@ bool TransformationManager::initializeCompilerInstance(std::string &ErrorMsg)
   }
 
   TargetInfo *Target = 
+#if LLVM_VERSION_MAJOR >= 21
+    TargetInfo::CreateTargetInfo(ClangInstance->getDiagnostics(),
+                                 ClangInstance->getInvocation().getTargetOpts());
+#else
     TargetInfo::CreateTargetInfo(ClangInstance->getDiagnostics(),
                                  ClangInstance->getInvocation().TargetOpts);
+#endif
   ClangInstance->setTarget(Target);
 
   if (const char *env = getenv("CREDUCE_INCLUDE_PATH")) {


### PR DESCRIPTION
split into patches for review:

* clang-21: fix DTST->getIdentifier()
* clang-21: remove TypeSpecWithTemplate
* clang-21: OpenCLKernelAttr --> DeviceKernelAttr
* clang-21: avoid deprecated FileManager::getDirectory
    * this existed in llvm 16 so is not ifdef'd
* clang-21: call CompilerInvocation::getTargetOpts

Depends on #285 and #287 to get a working build.

I chose not to stack on them since the patches commute.